### PR TITLE
[Feat] 카카오 로그인 및 AuthState 상태관리 로직 구현

### DIFF
--- a/TeumTeumEat/TeumTeumEat.xcodeproj/project.pbxproj
+++ b/TeumTeumEat/TeumTeumEat.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		46AE2AA12F0125BD0061B2EE /* KakaoSDK in Frameworks */ = {isa = PBXBuildFile; productRef = 46AE2AA02F0125BD0061B2EE /* KakaoSDK */; };
+		46AE2AA32F0125BD0061B2EE /* KakaoSDKAuth in Frameworks */ = {isa = PBXBuildFile; productRef = 46AE2AA22F0125BD0061B2EE /* KakaoSDKAuth */; };
 		46FE6B842EEACE0B009E626A /* ComposableArchitecture in Frameworks */ = {isa = PBXBuildFile; productRef = 46FE6B832EEACE0B009E626A /* ComposableArchitecture */; };
 /* End PBXBuildFile section */
 
@@ -70,6 +72,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				46FE6B842EEACE0B009E626A /* ComposableArchitecture in Frameworks */,
+				46AE2AA12F0125BD0061B2EE /* KakaoSDK in Frameworks */,
+				46AE2AA32F0125BD0061B2EE /* KakaoSDKAuth in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -131,6 +135,8 @@
 			name = TeumTeumEat;
 			packageProductDependencies = (
 				46FE6B832EEACE0B009E626A /* ComposableArchitecture */,
+				46AE2AA02F0125BD0061B2EE /* KakaoSDK */,
+				46AE2AA22F0125BD0061B2EE /* KakaoSDKAuth */,
 			);
 			productName = TeumTeumEat;
 			productReference = 46FE666E2EE1770E009E626A /* TeumTeumEat.app */;
@@ -216,6 +222,7 @@
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
 				46FE6B822EEACE0B009E626A /* XCRemoteSwiftPackageReference "swift-composable-architecture" */,
+				46AE2A9F2F0125BD0061B2EE /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 46FE666F2EE1770E009E626A /* Products */;
@@ -414,6 +421,8 @@
 		};
 		46FE66902EE17711009E626A /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReferenceAnchor = 46FE66702EE1770E009E626A /* TeumTeumEat */;
+			baseConfigurationReferenceRelativePath = Resources/Config.xcconfig;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -447,6 +456,8 @@
 		};
 		46FE66912EE17711009E626A /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReferenceAnchor = 46FE66702EE1770E009E626A /* TeumTeumEat */;
+			baseConfigurationReferenceRelativePath = Resources/Config.xcconfig;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -592,6 +603,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		46AE2A9F2F0125BD0061B2EE /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/kakao/kakao-ios-sdk";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.26.0;
+			};
+		};
 		46FE6B822EEACE0B009E626A /* XCRemoteSwiftPackageReference "swift-composable-architecture" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/pointfreeco/swift-composable-architecture.git";
@@ -603,6 +622,16 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		46AE2AA02F0125BD0061B2EE /* KakaoSDK */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 46AE2A9F2F0125BD0061B2EE /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */;
+			productName = KakaoSDK;
+		};
+		46AE2AA22F0125BD0061B2EE /* KakaoSDKAuth */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 46AE2A9F2F0125BD0061B2EE /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */;
+			productName = KakaoSDKAuth;
+		};
 		46FE6B832EEACE0B009E626A /* ComposableArchitecture */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 46FE6B822EEACE0B009E626A /* XCRemoteSwiftPackageReference "swift-composable-architecture" */;

--- a/TeumTeumEat/TeumTeumEat/App/TeumTeumEatApp.swift
+++ b/TeumTeumEat/TeumTeumEat/App/TeumTeumEatApp.swift
@@ -7,9 +7,17 @@
 
 import ComposableArchitecture
 import SwiftUI
+import KakaoSDKAuth
+import KakaoSDKCommon
 
 @main
 struct TeumTeumEatApp: App {
+
+    init() {
+        let APPKEY = Config.kakaoNativeAppKey
+        KakaoSDK.initSDK(appKey: APPKEY)
+    }
+    
     var body: some Scene {
         WindowGroup {
             AppView(
@@ -17,6 +25,11 @@ struct TeumTeumEatApp: App {
                     AppFeature()
                 }
             )
+            .onOpenURL(perform:{ url in
+                if(AuthApi.isKakaoTalkLoginUrl(url)){
+                    _ = AuthController.handleOpenUrl(url:url)
+                }
+            })
         }
     }
 }

--- a/TeumTeumEat/TeumTeumEat/Features/App/AppFeature.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/App/AppFeature.swift
@@ -53,12 +53,20 @@ struct AppFeature {
                 state.isShowingSplash = false
                 
                 switch authState {
-                case .authenticated:
-                    // 토큰 있음 → TODO: 메인 화면
-                    print("인증됨 - 메인 화면으로 이동 예정")
+                case .authenticated(let isOnboardingCompleted):
+                    if isOnboardingCompleted {
+                        // 온보딩 완료 → 메인 화면
+                        print("토큰 있음 & 온보딩 완료 → 메인")
+                        // TODO: state.mainTab = MainTabFeature.State()
+                    } else {
+                        // 온보딩 미완료 → 온보딩 화면
+                        print("토큰 있음 & 온보딩 미완료 → 온보딩")
+                        state.onboarding = OnboardingFeature.State()
+                    }
                     
                 case .unauthenticated:
                     // 토큰 없음 → 로그인 화면
+                    print("토큰 없음 → 로그인")
                     state.login = LoginFeature.State()
                 }
                 return .none
@@ -66,6 +74,7 @@ struct AppFeature {
             // Login Delegate
             case .login(.delegate(.loginSuccess(let accessToken, let refreshToken, let isOnboardingCompleted))):
                 state.login = nil
+                UserDefaultsManager.isOnboardingCompleted = isOnboardingCompleted
                 
                 if isOnboardingCompleted {
                     // 온보딩 완료 → TODO: 메인 화면
@@ -88,6 +97,7 @@ struct AppFeature {
                 // 온보딩 완료 → TODO: 메인 화면 (나중에 구현)
                 state.onboarding = nil
                 print("온보딩 완료 - 메인 화면으로 이동 예정")
+                UserDefaultsManager.isOnboardingCompleted = true
                 return .none
                 
             case .splash, .login, .termsAgreement, .onboarding:

--- a/TeumTeumEat/TeumTeumEat/Features/App/AppFeature.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/App/AppFeature.swift
@@ -23,6 +23,7 @@ struct AppFeature {
         case login(LoginFeature.Action)
         case termsAgreement(TermsAgreementFeature.Action)
         case onboarding(OnboardingFeature.Action)
+        case logout
     }
     
     var body: some ReducerOf<Self> {
@@ -32,6 +33,21 @@ struct AppFeature {
         
         Reduce { state, action in
             switch action {
+                
+            case .logout:
+                // 토큰 삭제
+                KeyChainManager.shared.deleteAll()
+                
+                state.login = nil
+                state.termsAgreement = nil
+                state.onboarding = nil
+                
+                // 로그인 화면으로
+                state.login = LoginFeature.State()
+                
+                print("로그아웃 완료 - 로그인 화면으로 이동")
+                
+                return .none
             // Splash
             case .splash(.authenticationChecked(let authState)):
                 state.isShowingSplash = false

--- a/TeumTeumEat/TeumTeumEat/Features/App/AppFeature.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/App/AppFeature.swift
@@ -12,19 +12,17 @@ struct AppFeature {
     @ObservableState
     struct State: Equatable {
         var splash: SplashFeature.State = .init()
-        var onboarding: OnboardingFeature.State?
+        var login: LoginFeature.State?
         var termsAgreement: TermsAgreementFeature.State?
-        var mainTab: MainTabFeature.State?
+        var onboarding: OnboardingFeature.State?
         var isShowingSplash = true
     }
     
     enum Action {
         case splash(SplashFeature.Action)
-        case splashCompleted
         case login(LoginFeature.Action)
         case termsAgreement(TermsAgreementFeature.Action)
         case onboarding(OnboardingFeature.Action)
-        case mainTab(MainTabFeature.Action)
     }
     
     var body: some ReducerOf<Self> {
@@ -34,45 +32,66 @@ struct AppFeature {
         
         Reduce { state, action in
             switch action {
+            // Splash
             case .splash(.authenticationChecked(let authState)):
                 state.isShowingSplash = false
                 
                 switch authState {
                 case .authenticated:
-                    // 토큰 있음 → 메인 화면
-                    state.mainTab = MainTabFeature.State()
+                    // 토큰 있음 → TODO: 메인 화면
+                    print("인증됨 - 메인 화면으로 이동 예정")
                     
                 case .unauthenticated:
                     // 토큰 없음 → 로그인 화면
                     state.login = LoginFeature.State()
                 }
                 return .none
-            
-            // LoginFeature Delegate 처리 추가
-            case .login(.delegate(.loginSuccess)):
-                // 기존 유저 로그인 성공 → 메인 화면
+                
+            // Login Delegate
+            case .login(.delegate(.loginSuccess(let accessToken, let refreshToken, let isOnboardingCompleted))):
                 state.login = nil
-                state.mainTab = MainTabFeature.State()
+                
+                if isOnboardingCompleted {
+                    // 온보딩 완료 → TODO: 메인 화면
+                    print("로그인 성공 & 온보딩 완료 - 메인 화면으로 이동 예정")
+                } else {
+                    // 온보딩 미완료 → 온보딩 화면
+                    state.onboarding = OnboardingFeature.State()
+                }
                 return .none
                 
-            case .login(.delegate(.signUpRequired)):
-                // 신규 유저 → 약관 동의 화면으로
+            case .login(.delegate(.needsTermsAgreement(let idToken))):
+                // 신규 유저 → 약관 동의 화면
                 state.login = nil
-                state.termsAgreement = TermsAgreementFeature.State()
+                state.termsAgreement = TermsAgreementFeature.State(idToken: idToken)
                 return .none
                 
-            case .splash, .login, .onboarding, .mainTab:
+            // TermsAgreement Delegate
+            case .termsAgreement(.delegate(.signUpSuccess)):
+                // 약관 동의 & 회원가입 성공 → 온보딩 화면
+                state.termsAgreement = nil
+                state.onboarding = OnboardingFeature.State()
+                return .none
+                
+            // Onboarding Delegate
+            case .onboarding(.complete(.startButtonTapped)):
+                // 온보딩 완료 → TODO: 메인 화면 (나중에 구현)
+                state.onboarding = nil
+                print("온보딩 완료 - 메인 화면으로 이동 예정")
+                return .none
+                
+            case .splash, .login, .termsAgreement, .onboarding:
                 return .none
             }
         }
         .ifLet(\.login, action: \.login) {
             LoginFeature()
         }
+        .ifLet(\.termsAgreement, action: \.termsAgreement) {
+            TermsAgreementFeature()
+        }
         .ifLet(\.onboarding, action: \.onboarding) {
             OnboardingFeature()
-        }
-        .ifLet(\.mainTab, action: \.mainTab) {
-            MainTabFeature()
         }
     }
 }

--- a/TeumTeumEat/TeumTeumEat/Features/App/AppFeature.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/App/AppFeature.swift
@@ -13,6 +13,7 @@ struct AppFeature {
     struct State: Equatable {
         var splash: SplashFeature.State = .init()
         var onboarding: OnboardingFeature.State?
+        var termsAgreement: TermsAgreementFeature.State?
         var mainTab: MainTabFeature.State?
         var isShowingSplash = true
     }
@@ -20,6 +21,8 @@ struct AppFeature {
     enum Action {
         case splash(SplashFeature.Action)
         case splashCompleted
+        case login(LoginFeature.Action)
+        case termsAgreement(TermsAgreementFeature.Action)
         case onboarding(OnboardingFeature.Action)
         case mainTab(MainTabFeature.Action)
     }
@@ -43,6 +46,19 @@ struct AppFeature {
                     // 토큰 없음 → 로그인 화면
                     state.login = LoginFeature.State()
                 }
+                return .none
+            
+            // LoginFeature Delegate 처리 추가
+            case .login(.delegate(.loginSuccess)):
+                // 기존 유저 로그인 성공 → 메인 화면
+                state.login = nil
+                state.mainTab = MainTabFeature.State()
+                return .none
+                
+            case .login(.delegate(.signUpRequired)):
+                // 신규 유저 → 약관 동의 화면으로
+                state.login = nil
+                state.termsAgreement = TermsAgreementFeature.State()
                 return .none
                 
             case .splash, .login, .onboarding, .mainTab:

--- a/TeumTeumEat/TeumTeumEat/Features/App/AppFeature.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/App/AppFeature.swift
@@ -76,12 +76,6 @@ struct AppFeature {
                 }
                 return .none
                 
-            case .login(.delegate(.needsTermsAgreement(let idToken))):
-                // 신규 유저 → 약관 동의 화면
-                state.login = nil
-                state.termsAgreement = TermsAgreementFeature.State(idToken: idToken)
-                return .none
-                
             // TermsAgreement Delegate
             case .termsAgreement(.delegate(.signUpSuccess)):
                 // 약관 동의 & 회원가입 성공 → 온보딩 화면

--- a/TeumTeumEat/TeumTeumEat/Features/App/AppFeature.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/App/AppFeature.swift
@@ -13,6 +13,7 @@ struct AppFeature {
     struct State: Equatable {
         var splash: SplashFeature.State = .init()
         var onboarding: OnboardingFeature.State?
+        var mainTab: MainTabFeature.State?
         var isShowingSplash = true
     }
     
@@ -20,6 +21,7 @@ struct AppFeature {
         case splash(SplashFeature.Action)
         case splashCompleted
         case onboarding(OnboardingFeature.Action)
+        case mainTab(MainTabFeature.Action)
     }
     
     var body: some ReducerOf<Self> {
@@ -29,18 +31,32 @@ struct AppFeature {
         
         Reduce { state, action in
             switch action {
-            case .splash(.checkAuthenticationComplete):
+            case .splash(.authenticationChecked(let authState)):
                 state.isShowingSplash = false
-                state.onboarding = OnboardingFeature.State()
-                return .send(.splashCompleted)
-            case .splashCompleted:
+                
+                switch authState {
+                case .authenticated:
+                    // 토큰 있음 → 메인 화면
+                    state.mainTab = MainTabFeature.State()
+                    
+                case .unauthenticated:
+                    // 토큰 없음 → 로그인 화면
+                    state.login = LoginFeature.State()
+                }
                 return .none
-            case .splash, .onboarding:
+                
+            case .splash, .login, .onboarding, .mainTab:
                 return .none
             }
         }
+        .ifLet(\.login, action: \.login) {
+            LoginFeature()
+        }
         .ifLet(\.onboarding, action: \.onboarding) {
             OnboardingFeature()
+        }
+        .ifLet(\.mainTab, action: \.mainTab) {
+            MainTabFeature()
         }
     }
 }

--- a/TeumTeumEat/TeumTeumEat/Features/App/AppView.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/App/AppView.swift
@@ -16,10 +16,21 @@ struct AppView: View {
             SplashView(store: store.scope(state: \.splash, action: \.splash))
         } else if let loginStore = store.scope(state: \.login, action: \.login) {
             LoginView(store: loginStore)
+        } else if let termsStore = store.scope(state: \.termsAgreement, action: \.termsAgreement) {
+            TermsAgreementView(store: termsStore)
         } else if let onboardingStore = store.scope(state: \.onboarding, action: \.onboarding) {
             OnboardingView(store: onboardingStore)
-        } else if let mainTabStore = store.scope(state: \.mainTab, action: \.mainTab) {
-            MainTabView(store: mainTabStore)
+        } else {
+            // TODO: MainTab 구현 전 임시 화면
+            VStack {
+                Text("메인 화면")
+                    .font(.largeTitle)
+                    .fontWeight(.bold)
+                
+                Text("MainTab 구현 예정")
+                    .foregroundColor(.gray)
+                    .padding(.top, 8)
+            }
         }
     }
 }

--- a/TeumTeumEat/TeumTeumEat/Features/App/AppView.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/App/AppView.swift
@@ -10,14 +10,16 @@ import SwiftUI
 
 struct AppView: View {
     let store: StoreOf<AppFeature>
-                        
+    
     var body: some View {
         if store.isShowingSplash {
             SplashView(store: store.scope(state: \.splash, action: \.splash))
+        } else if let loginStore = store.scope(state: \.login, action: \.login) {
+            LoginView(store: loginStore)
         } else if let onboardingStore = store.scope(state: \.onboarding, action: \.onboarding) {
             OnboardingView(store: onboardingStore)
-        } else {
-            Text("메인화면")
+        } else if let mainTabStore = store.scope(state: \.mainTab, action: \.mainTab) {
+            MainTabView(store: mainTabStore)
         }
     }
 }

--- a/TeumTeumEat/TeumTeumEat/Features/App/AppView.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/App/AppView.swift
@@ -16,35 +16,28 @@ struct AppView: View {
             SplashView(store: store.scope(state: \.splash, action: \.splash))
         } else if let loginStore = store.scope(state: \.login, action: \.login) {
             LoginView(store: loginStore)
-        } else if let termsStore = store.scope(state: \.termsAgreement, action: \.termsAgreement) {
-            TermsAgreementView(store: termsStore)
         } else if let onboardingStore = store.scope(state: \.onboarding, action: \.onboarding) {
             OnboardingView(store: onboardingStore)
         } else {
-            // TODO: MainTab 구현 전 임시 화면
             VStack {
                 Text("메인 화면")
                     .font(.largeTitle)
                     .fontWeight(.bold)
                 
-                Text("MainTab 구현 예정")
-                    .foregroundColor(.gray)
-                    .padding(.top, 8)
-                
                 Button {
-                     store.send(.logout)
-                 } label: {
-                     HStack {
-                         Image(systemName: "rectangle.portrait.and.arrow.right")
-                         Text("로그아웃")
-                     }
-                     .foregroundColor(.white)
-                     .padding(.horizontal, 30)
-                     .padding(.vertical, 12)
-                     .background(Color.red)
-                     .cornerRadius(10)
-                 }
-                 .padding(.top, 40)
+                    store.send(.logout)
+                } label: {
+                    HStack {
+                        Image(systemName: "rectangle.portrait.and.arrow.right")
+                        Text("로그아웃")
+                    }
+                    .foregroundColor(.white)
+                    .padding(.horizontal, 30)
+                    .padding(.vertical, 12)
+                    .background(Color.red)
+                    .cornerRadius(10)
+                }
+                .padding(.top, 40)
             }
         }
     }

--- a/TeumTeumEat/TeumTeumEat/Features/App/AppView.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/App/AppView.swift
@@ -30,6 +30,21 @@ struct AppView: View {
                 Text("MainTab 구현 예정")
                     .foregroundColor(.gray)
                     .padding(.top, 8)
+                
+                Button {
+                     store.send(.logout)
+                 } label: {
+                     HStack {
+                         Image(systemName: "rectangle.portrait.and.arrow.right")
+                         Text("로그아웃")
+                     }
+                     .foregroundColor(.white)
+                     .padding(.horizontal, 30)
+                     .padding(.vertical, 12)
+                     .background(Color.red)
+                     .cornerRadius(10)
+                 }
+                 .padding(.top, 40)
             }
         }
     }

--- a/TeumTeumEat/TeumTeumEat/Features/Login/AppConfig.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/Login/AppConfig.swift
@@ -28,8 +28,8 @@ enum Config  {
         return key
     }
     
-    static var apiBaseURL: String {
-        guard let url = Bundle.main.object(forInfoDictionaryKey: "API_BASE_URL") as? String else {
+    static var baseURL: String {
+        guard let url = Bundle.main.object(forInfoDictionaryKey: "BASE_URL") as? String else {
             fatalError("API_BASE_URL not found")
         }
         return url

--- a/TeumTeumEat/TeumTeumEat/Features/Login/AppConfig.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/Login/AppConfig.swift
@@ -1,0 +1,37 @@
+//
+//  AppConfig.swift
+//  TeumTeumEat
+//
+//  Created by 임재현 on 12/28/25.
+//
+
+import Foundation
+
+protocol ConfigProtocol {
+    var kakaoAppKey: String { get }
+    var apiBaseURL: String { get }
+}
+
+enum Config  {
+
+    static var kakaoNativeAppKey: String {
+        guard let key = Bundle.main.object(forInfoDictionaryKey: "KAKAO_NATIVE_APPKEY") as? String else {
+            fatalError("KAKAO_NATIVE_APPKEY not found")
+        }
+        return key
+    }
+    
+    static var kakaoAPIKey: String {
+        guard let key = Bundle.main.object(forInfoDictionaryKey: "KAKAO_API_KEY") as? String else {
+            fatalError("KAKAO_APP_KEY not found")
+        }
+        return key
+    }
+    
+    static var apiBaseURL: String {
+        guard let url = Bundle.main.object(forInfoDictionaryKey: "API_BASE_URL") as? String else {
+            fatalError("API_BASE_URL not found")
+        }
+        return url
+    }
+}

--- a/TeumTeumEat/TeumTeumEat/Features/Login/LoginFeature.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/Login/LoginFeature.swift
@@ -16,14 +16,20 @@ struct LoginFeature {
         var isLoading = false
         var errorMessage: String?
         var pendingIdToken: String?
+        var pendingProvider: SocialProvider?
         var showTermsSheet = false
+    }
+    
+    enum SocialProvider: String {
+        case kakao = "KAKAO"
+        case appleProvider = "APPLE"
     }
     
     enum Action {
         case kakaoLoginTapped
         case appleLoginTapped
 
-        case loginAttempt(idToken: String, termsAgreed: Bool)
+        case loginAttempt(idToken: String, provider: SocialProvider, termsAgreed: Bool)
         case loginResponse(Result<SocialLoginResponse, Error>)
         
         case dismissTermsSheet
@@ -52,7 +58,7 @@ struct LoginFeature {
                         print("ID Token: \(kakaoIdToken)")
                         print("Token Length: \(kakaoIdToken.count)")
                         print("서버 로그인 시도 (termsAgreed: false)")
-                        await send(.loginAttempt(idToken: kakaoIdToken, termsAgreed: false))
+                        await send(.loginAttempt(idToken: kakaoIdToken, provider: .kakao, termsAgreed: false))
                     } catch {
                         print("카카오 로그인 전체 실패:", error)
                         await send(.loginResponse(.failure(error)))
@@ -66,16 +72,17 @@ struct LoginFeature {
                 return .run { send in
                     do {
                         let idToken = try await loginWithAppleSDK()
-                        await send(.loginAttempt(idToken: idToken, termsAgreed: false))
+                        await send(.loginAttempt(idToken: idToken, provider: .appleProvider, termsAgreed: false))
                     } catch {
                         await send(.loginResponse(.failure(error)))
                     }
                 }
                 
-            case .loginAttempt(let idToken, let termsAgreed):
+            case .loginAttempt(let idToken,let provider, let termsAgreed):
                 state.isLoading = true
                 state.errorMessage = nil
                 state.pendingIdToken = idToken
+                state.pendingProvider = provider
                 
                 print("서버 로그인 요청")
                 print("idToken: \(String(idToken.prefix(20)))...")
@@ -85,6 +92,7 @@ struct LoginFeature {
                     do {
                         let response = try await loginToServer(
                             idToken: idToken,
+                            provider: provider,
                             termsAgreed: termsAgreed
                         )
                         
@@ -161,13 +169,18 @@ struct LoginFeature {
                  print("약관 동의 확인 - 재로그인 시도")
                  state.showTermsSheet = false
                  
-                 guard let idToken = state.pendingIdToken else {
-                     state.errorMessage = "토큰 정보가 없습니다."
+                 guard let idToken = state.pendingIdToken,
+                       let provider = state.pendingProvider else {
+                     state.errorMessage = "토큰 또는 Provider 정보가 없습니다."
                      return .none
                  }
                  
                  // termsAgreed: true로 재시도
-                 return .send(.loginAttempt(idToken: idToken, termsAgreed: true))
+                 return .send(.loginAttempt(
+                     idToken: idToken,
+                     provider: provider,
+                     termsAgreed: true
+                 ))
                 
             case .delegate:
                 return .none
@@ -209,10 +222,10 @@ extension LoginFeature {
         }
     }
     
-    private func loginToServer(idToken: String, termsAgreed: Bool) async throws -> SocialLoginResponse {
+    private func loginToServer(idToken: String, provider: SocialProvider, termsAgreed: Bool) async throws -> SocialLoginResponse {
         print("서버 API 호출 시작")
         let baseURL = Config.baseURL
-        let endPoint = "/api/v1/auth/oauth/register?provider=KAKAO"
+        let endPoint = "/api/v1/auth/oauth/register?provider=\(provider.rawValue)"
         let fullPath = baseURL + endPoint
         print("fullpath: \(fullPath)")
         

--- a/TeumTeumEat/TeumTeumEat/Features/Login/LoginFeature.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/Login/LoginFeature.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import ComposableArchitecture
+import KakaoSDKUser
 
 @Reducer
 struct LoginFeature {
@@ -121,14 +122,34 @@ struct LoginFeature {
 }
 
 extension LoginFeature {
-    private func loginWithKakaoSDK() async throws -> String {
-        // TODO: 카카오 SDK 연동
-        fatalError("카카오 SDK 연동 필요")
-    }
-    
+
     private func loginWithAppleSDK() async throws -> String {
         // TODO: Apple SDK 연동
         fatalError("Apple SDK 연동 필요")
+    }
+    
+    private func loginWithKakaoSDK() async throws -> String {
+        return try await withCheckedThrowingContinuation { continuation in
+            if UserApi.isKakaoTalkLoginAvailable() {
+                UserApi.shared.loginWithKakaoTalk { oauthToken, error in
+                    if let error = error {
+                        continuation.resume(throwing: error)
+                    } else if let token = oauthToken {
+                        print("카카오톡 로그인 성공")
+                        continuation.resume(returning: token.accessToken)
+                    }
+                }
+            } else {
+                UserApi.shared.loginWithKakaoAccount { oauthToken, error in
+                    if let error = error {
+                        continuation.resume(throwing: error)
+                    } else if let token = oauthToken {
+                        print("카카오 계정 로그인 성공")
+                        continuation.resume(returning: token.accessToken)
+                    }
+                }
+            }
+        }
     }
     
     private func loginToServer(idToken: String, termsAgreed: Bool) async throws -> SocialLoginResponse {

--- a/TeumTeumEat/TeumTeumEat/Features/Login/LoginFeature.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/Login/LoginFeature.swift
@@ -14,18 +14,21 @@ struct LoginFeature {
     struct State: Equatable {
         var isLoading = false
         var errorMessage: String?
+        var pendingIdToken: String?
     }
     
     enum Action {
         case kakaoLoginTapped
         case appleLoginTapped
-        
+
+        case loginAttempt(idToken: String, termsAgreed: Bool)
         case loginResponse(Result<SocialLoginResponse, Error>)
+        
         case delegate(Delegate)
         
         enum Delegate {
-            case loginSuccess(accessToken: String, refreshToken: String)
-            case signUpRequired(isNewUser: Bool)
+            case loginSuccess(accessToken: String, refreshToken: String, isOnboardingCompleted: Bool)
+            case needsTermsAgreement(idToken: String)
         }
     }
     
@@ -38,16 +41,8 @@ struct LoginFeature {
                 
                 return .run { send in
                     do {
-                        // 1. 카카오 SDK로 로그인 → idToken 받기
                         let idToken = try await loginWithKakaoSDK()
-                        
-                        // 2. 서버에 idToken 전달
-                        let response = try await loginToServer(
-                            provider: "kakao",
-                            idToken: idToken
-                        )
-                        
-                        await send(.loginResponse(.success(response)))
+                        await send(.loginAttempt(idToken: idToken, termsAgreed: false))
                     } catch {
                         await send(.loginResponse(.failure(error)))
                     }
@@ -60,9 +55,21 @@ struct LoginFeature {
                 return .run { send in
                     do {
                         let idToken = try await loginWithAppleSDK()
+                        await send(.loginAttempt(idToken: idToken, termsAgreed: false))
+                    } catch {
+                        await send(.loginResponse(.failure(error)))
+                    }
+                }
+                
+            case .loginAttempt(let idToken, let termsAgreed):
+                state.isLoading = true
+                state.errorMessage = nil
+                
+                return .run { send in
+                    do {
                         let response = try await loginToServer(
-                            provider: "apple",
-                            idToken: idToken
+                            idToken: idToken,
+                            termsAgreed: termsAgreed
                         )
                         await send(.loginResponse(.success(response)))
                     } catch {
@@ -70,31 +77,35 @@ struct LoginFeature {
                     }
                 }
                 
-
             case .loginResponse(.success(let response)):
                 state.isLoading = false
                 
-                guard let data = response.data else {
-                    state.errorMessage = "로그인 응답 데이터가 없습니다."
-                    return .none
-                }
-                
-                // 신규 유저 체크
-                if data.isNewUser == true {
-                    // 토큰은 우선 저장 (약관 동의 후 회원가입에 사용)
-                    KeyChainManager.shared.saveAccessToken(data.accessToken)
-                    KeyChainManager.shared.saveRefreshToken(data.refreshToken)
+                if response.code == "OK" {
+                    // 로그인 성공 (기존 유저 또는 약관 동의 완료한 신규 유저)
+                    guard let data = response.data else {
+                        state.errorMessage = "응답 데이터가 없습니다."
+                        return .none
+                    }
                     
-                    return .send(.delegate(.signUpRequired(isNewUser: true)))
-                } else {
-                    // 기존 유저 → 토큰 저장
+                    // 토큰 저장
                     KeyChainManager.shared.saveAccessToken(data.accessToken)
                     KeyChainManager.shared.saveRefreshToken(data.refreshToken)
                     
                     return .send(.delegate(.loginSuccess(
                         accessToken: data.accessToken,
-                        refreshToken: data.refreshToken
+                        refreshToken: data.refreshToken,
+                        isOnboardingCompleted: data.isOnboardingCompleted
                     )))
+                    
+                } else if response.code == "NEED_TERMS_AGREEMENT" {
+                    // 신규 유저 → 약관 동의 필요
+                    // pendingIdToken은 이미 state에 저장되어 있음
+                    return .send(.delegate(.needsTermsAgreement(idToken: state.pendingIdToken ?? "")))
+                    
+                } else {
+                    // 기타 에러
+                    state.errorMessage = response.message
+                    return .none
                 }
                 
             case .loginResponse(.failure(let error)):
@@ -118,5 +129,21 @@ extension LoginFeature {
     private func loginWithAppleSDK() async throws -> String {
         // TODO: Apple SDK 연동
         fatalError("Apple SDK 연동 필요")
+    }
+    
+    private func loginToServer(idToken: String, termsAgreed: Bool) async throws -> SocialLoginResponse {
+        let url = URL(string: "")!
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(idToken)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        
+        let body = SocialLoginRequest(termsAgreed: termsAgreed)
+        request.httpBody = try JSONEncoder().encode(body)
+        
+        let (data, _) = try await URLSession.shared.data(for: request)
+        let response = try JSONDecoder().decode(SocialLoginResponse.self, from: data)
+        
+        return response
     }
 }

--- a/TeumTeumEat/TeumTeumEat/Features/Login/LoginFeature.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/Login/LoginFeature.swift
@@ -16,6 +16,7 @@ struct LoginFeature {
         var isLoading = false
         var errorMessage: String?
         var pendingIdToken: String?
+        var showTermsSheet = false
     }
     
     enum Action {
@@ -25,11 +26,13 @@ struct LoginFeature {
         case loginAttempt(idToken: String, termsAgreed: Bool)
         case loginResponse(Result<SocialLoginResponse, Error>)
         
+        case dismissTermsSheet
+        case agreeTermsTapped
+        
         case delegate(Delegate)
         
         enum Delegate {
             case loginSuccess(accessToken: String, refreshToken: String, isOnboardingCompleted: Bool)
-            case needsTermsAgreement(idToken: String)
         }
     }
     
@@ -131,12 +134,13 @@ struct LoginFeature {
                         isOnboardingCompleted: data.isOnboardingCompleted
                     )))
                     
-                } else if response.code == "NEED_TERMS_AGREEMENT" {
+                } else if response.code == "AUTH-006" {
                     // 신규 유저 → 약관 동의 필요
                     // pendingIdToken은 이미 state에 저장되어 있음
                     print("약관 동의 필요 (신규 유저)")
-                    return .send(.delegate(.needsTermsAgreement(idToken: state.pendingIdToken ?? "")))
-                    
+                    state.showTermsSheet = true
+                    return .none
+
                 } else {
                     // 기타 에러
                     state.errorMessage = response.message
@@ -146,7 +150,24 @@ struct LoginFeature {
             case .loginResponse(.failure(let error)):
                 state.isLoading = false
                 state.errorMessage = error.localizedDescription
+                print("서버 로그인 실패: \(error)")
                 return .none
+                
+            case .dismissTermsSheet:
+                state.showTermsSheet = false
+                return .none
+                
+            case .agreeTermsTapped:
+                 print("약관 동의 확인 - 재로그인 시도")
+                 state.showTermsSheet = false
+                 
+                 guard let idToken = state.pendingIdToken else {
+                     state.errorMessage = "토큰 정보가 없습니다."
+                     return .none
+                 }
+                 
+                 // termsAgreed: true로 재시도
+                 return .send(.loginAttempt(idToken: idToken, termsAgreed: true))
                 
             case .delegate:
                 return .none

--- a/TeumTeumEat/TeumTeumEat/Features/Login/LoginFeature.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/Login/LoginFeature.swift
@@ -1,0 +1,122 @@
+//
+//  LoginFeature.swift
+//  TeumTeumEat
+//
+//  Created by 임재현 on 12/28/25.
+//
+
+import Foundation
+import ComposableArchitecture
+
+@Reducer
+struct LoginFeature {
+    @ObservableState
+    struct State: Equatable {
+        var isLoading = false
+        var errorMessage: String?
+    }
+    
+    enum Action {
+        case kakaoLoginTapped
+        case appleLoginTapped
+        
+        case loginResponse(Result<SocialLoginResponse, Error>)
+        case delegate(Delegate)
+        
+        enum Delegate {
+            case loginSuccess(accessToken: String, refreshToken: String)
+            case signUpRequired(isNewUser: Bool)
+        }
+    }
+    
+    var body: some ReducerOf<Self> {
+        Reduce { state, action in
+            switch action {
+            case .kakaoLoginTapped:
+                state.isLoading = true
+                state.errorMessage = nil
+                
+                return .run { send in
+                    do {
+                        // 1. 카카오 SDK로 로그인 → idToken 받기
+                        let idToken = try await loginWithKakaoSDK()
+                        
+                        // 2. 서버에 idToken 전달
+                        let response = try await loginToServer(
+                            provider: "kakao",
+                            idToken: idToken
+                        )
+                        
+                        await send(.loginResponse(.success(response)))
+                    } catch {
+                        await send(.loginResponse(.failure(error)))
+                    }
+                }
+                
+            case .appleLoginTapped:
+                state.isLoading = true
+                state.errorMessage = nil
+                
+                return .run { send in
+                    do {
+                        let idToken = try await loginWithAppleSDK()
+                        let response = try await loginToServer(
+                            provider: "apple",
+                            idToken: idToken
+                        )
+                        await send(.loginResponse(.success(response)))
+                    } catch {
+                        await send(.loginResponse(.failure(error)))
+                    }
+                }
+                
+
+            case .loginResponse(.success(let response)):
+                state.isLoading = false
+                
+                guard let data = response.data else {
+                    state.errorMessage = "로그인 응답 데이터가 없습니다."
+                    return .none
+                }
+                
+                // 신규 유저 체크
+                if data.isNewUser == true {
+                    // 토큰은 우선 저장 (약관 동의 후 회원가입에 사용)
+                    KeyChainManager.shared.saveAccessToken(data.accessToken)
+                    KeyChainManager.shared.saveRefreshToken(data.refreshToken)
+                    
+                    return .send(.delegate(.signUpRequired(isNewUser: true)))
+                } else {
+                    // 기존 유저 → 토큰 저장
+                    KeyChainManager.shared.saveAccessToken(data.accessToken)
+                    KeyChainManager.shared.saveRefreshToken(data.refreshToken)
+                    
+                    return .send(.delegate(.loginSuccess(
+                        accessToken: data.accessToken,
+                        refreshToken: data.refreshToken
+                    )))
+                }
+                
+            case .loginResponse(.failure(let error)):
+                state.isLoading = false
+                state.errorMessage = error.localizedDescription
+                return .none
+                
+            case .delegate:
+                return .none
+            }
+        }
+    }
+}
+
+extension LoginFeature {
+    private func loginWithKakaoSDK() async throws -> String {
+        // TODO: 카카오 SDK 연동
+        fatalError("카카오 SDK 연동 필요")
+    }
+    
+    private func loginWithAppleSDK() async throws -> String {
+        // TODO: Apple SDK 연동
+        fatalError("Apple SDK 연동 필요")
+    }
+}

--- a/TeumTeumEat/TeumTeumEat/Features/Login/LoginFeature.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/Login/LoginFeature.swift
@@ -37,14 +37,21 @@ struct LoginFeature {
         Reduce { state, action in
             switch action {
             case .kakaoLoginTapped:
+                print("카카오 로그인 버튼 탭")
                 state.isLoading = true
                 state.errorMessage = nil
                 
                 return .run { send in
                     do {
-                        let idToken = try await loginWithKakaoSDK()
-                        await send(.loginAttempt(idToken: idToken, termsAgreed: false))
+                        print("카카오 SDK 로그인 시작...")
+                        let kakaoIdToken = try await loginWithKakaoSDK()
+                        print("카카오 SDK 로그인 성공!")
+                        print("ID Token: \(kakaoIdToken)")
+                        print("Token Length: \(kakaoIdToken.count)")
+                        print("서버 로그인 시도 (termsAgreed: false)")
+                        await send(.loginAttempt(idToken: kakaoIdToken, termsAgreed: false))
                     } catch {
+                        print("카카오 로그인 전체 실패:", error)
                         await send(.loginResponse(.failure(error)))
                     }
                 }
@@ -65,6 +72,11 @@ struct LoginFeature {
             case .loginAttempt(let idToken, let termsAgreed):
                 state.isLoading = true
                 state.errorMessage = nil
+                state.pendingIdToken = idToken
+                
+                print("서버 로그인 요청")
+                print("idToken: \(String(idToken.prefix(20)))...")
+                print("termsAgreed: \(termsAgreed)")
                 
                 return .run { send in
                     do {
@@ -72,15 +84,27 @@ struct LoginFeature {
                             idToken: idToken,
                             termsAgreed: termsAgreed
                         )
+                        
+                        print("서버 응답 수신")
+                        print("Response Code: \(response.code)")
+                        print("Message: \(response.message)")
+                        
+                        if let data = response.data {
+                            print("AccessToken: \(String(data.accessToken))...")
+                            print("RefreshToken: \(String(data.refreshToken))...")
+                            print("isOnboardingCompleted: \(data.isOnboardingCompleted)")
+                        }
                         await send(.loginResponse(.success(response)))
                     } catch {
                         await send(.loginResponse(.failure(error)))
+                        print("서버 로그인 실패")
+                        print("Error: \(error.localizedDescription)")
                     }
                 }
                 
             case .loginResponse(.success(let response)):
                 state.isLoading = false
-                
+                print("응답 처리")
                 if response.code == "OK" {
                     // 로그인 성공 (기존 유저 또는 약관 동의 완료한 신규 유저)
                     guard let data = response.data else {
@@ -89,8 +113,17 @@ struct LoginFeature {
                     }
                     
                     // 토큰 저장
+                    print("토큰 저장 중...")
                     KeyChainManager.shared.saveAccessToken(data.accessToken)
                     KeyChainManager.shared.saveRefreshToken(data.refreshToken)
+                    print("토큰 저장 완료")
+                    
+                    print("다음 화면 분기:")
+                    if data.isOnboardingCompleted {
+                        print("   → 메인 화면 (온보딩 완료)")
+                    } else {
+                        print("   → 온보딩 화면 (온보딩 미완료)")
+                    }
                     
                     return .send(.delegate(.loginSuccess(
                         accessToken: data.accessToken,
@@ -101,6 +134,7 @@ struct LoginFeature {
                 } else if response.code == "NEED_TERMS_AGREEMENT" {
                     // 신규 유저 → 약관 동의 필요
                     // pendingIdToken은 이미 state에 저장되어 있음
+                    print("약관 동의 필요 (신규 유저)")
                     return .send(.delegate(.needsTermsAgreement(idToken: state.pendingIdToken ?? "")))
                     
                 } else {
@@ -136,7 +170,8 @@ extension LoginFeature {
                         continuation.resume(throwing: error)
                     } else if let token = oauthToken {
                         print("카카오톡 로그인 성공")
-                        continuation.resume(returning: token.accessToken)
+                        print("\(String(describing: token.idToken))")
+                        continuation.resume(returning: token.idToken ?? "")
                     }
                 }
             } else {
@@ -145,7 +180,8 @@ extension LoginFeature {
                         continuation.resume(throwing: error)
                     } else if let token = oauthToken {
                         print("카카오 계정 로그인 성공")
-                        continuation.resume(returning: token.accessToken)
+                        print("\(String(describing: token.idToken))")
+                        continuation.resume(returning: token.idToken ?? "")
                     }
                 }
             }
@@ -153,18 +189,93 @@ extension LoginFeature {
     }
     
     private func loginToServer(idToken: String, termsAgreed: Bool) async throws -> SocialLoginResponse {
-        let url = URL(string: "")!
+        print("서버 API 호출 시작")
+        let baseURL = Config.baseURL
+        let endPoint = "/api/v1/auth/oauth/register?provider=KAKAO"
+        let fullPath = baseURL + endPoint
+        print("fullpath: \(fullPath)")
+        
+        let url = URL(string: "\(fullPath)")!
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
-        request.setValue("Bearer \(idToken)", forHTTPHeaderField: "Authorization")
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         
-        let body = SocialLoginRequest(termsAgreed: termsAgreed)
+        let body = SocialLoginRequest(
+            idToken: idToken,
+            termsAgreed: termsAgreed,
+            name: "TestUser"
+        )
         request.httpBody = try JSONEncoder().encode(body)
         
-        let (data, _) = try await URLSession.shared.data(for: request)
+
+        if let headers = request.allHTTPHeaderFields {
+            for (key, value) in headers {
+                print("   \(key): \(value)")
+            }
+        } else {
+            print("헤더 없음")
+        }
+        
+        print("Request Body:")
+        if let bodyData = request.httpBody,
+           let bodyString = String(data: bodyData, encoding: .utf8) {
+            print("   Raw Data: \(bodyString)")
+            
+            if let jsonObject = try? JSONSerialization.jsonObject(with: bodyData),
+               let prettyData = try? JSONSerialization.data(withJSONObject: jsonObject, options: .prettyPrinted),
+               let prettyString = String(data: prettyData, encoding: .utf8) {
+                print("\n   Formatted JSON:")
+                print(prettyString.split(separator: "\n").map { "   \($0)" }.joined(separator: "\n"))
+            }
+        } else {
+            print("바디 없음")
+        }
+        
+        print("Request Body 구조:")
+        print("   idToken: \(String(idToken.prefix(30)))... (길이: \(idToken.count))")
+        print("   termsAgreed: \(termsAgreed)")
+        print("   name: TestUser")
+        
+        
+        let (data, httpResponse) = try await URLSession.shared.data(for: request)
+        
+        print("서버 응답 수신")
+        
+        if let httpResponse = httpResponse as? HTTPURLResponse {
+            print("HTTP Status Code: \(httpResponse.statusCode)")
+            
+            print("Response Headers:")
+            for (key, value) in httpResponse.allHeaderFields {
+                print("   \(key): \(value)")
+            }
+        }
+        
+        print("Response Body:")
+        
+        if let jsonString = String(data: data, encoding: .utf8) {
+            print("\n   Raw JSON:")
+            print("   \(jsonString)")
+            
+            if let jsonObject = try? JSONSerialization.jsonObject(with: data),
+               let prettyData = try? JSONSerialization.data(withJSONObject: jsonObject, options: .prettyPrinted),
+               let prettyString = String(data: prettyData, encoding: .utf8) {
+                print("\n   Formatted JSON:")
+                print(prettyString.split(separator: "\n").map { "   \($0)" }.joined(separator: "\n"))
+            }
+        }
+
+    
+        print("JSON Decoding")
         let response = try JSONDecoder().decode(SocialLoginResponse.self, from: data)
         
+        print("Decode 성공!")
+        print("   code: \(response.code)")
+        print("   message: \(response.message)")
+        if let data = response.data {
+            print("   data.accessToken: \(String(data.accessToken.prefix(20)))...")
+            print("   data.refreshToken: \(String(data.refreshToken.prefix(20)))...")
+            print("   data.isOnboardingCompleted: \(data.isOnboardingCompleted)")
+        }
         return response
     }
 }

--- a/TeumTeumEat/TeumTeumEat/Features/Login/LoginView.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/Login/LoginView.swift
@@ -57,7 +57,6 @@ struct LoginView: View {
                     .foregroundColor(.white)
                     .cornerRadius(10)
                 }
-                
             }
             .padding(.horizontal, 20)
             .disabled(store.isLoading)
@@ -77,5 +76,141 @@ struct LoginView: View {
             Spacer()
         }
         .padding()
+        .sheet(isPresented: .init(
+                    get: { store.showTermsSheet },
+                    set: { _ in store.send(.dismissTermsSheet) }
+                )) {
+                    TermsAgreementBottomSheet(
+                        onAgree: { store.send(.agreeTermsTapped) },
+                        onDismiss: { store.send(.dismissTermsSheet) }
+                    )
+                    .presentationDetents([.medium, .large])
+                }
+            }
+}
+struct TermsAgreementBottomSheet: View {
+    let onAgree: () -> Void
+    let onDismiss: () -> Void
+    
+    @State private var allAgreed = false
+    @State private var serviceTermsAgreed = false
+    @State private var privacyPolicyAgreed = false
+    @State private var ageConfirmationAgreed = false
+    @State private var marketingAgreed = false
+    
+    private var canProceed: Bool {
+        serviceTermsAgreed && privacyPolicyAgreed && ageConfirmationAgreed
+    }
+    
+    var body: some View {
+        VStack(spacing: 0) {
+            // 헤더
+            HStack {
+                Text("서비스 이용 약관")
+                    .font(.title2)
+                    .fontWeight(.bold)
+                
+                Spacer()
+                
+                Button {
+                    onDismiss()
+                } label: {
+                    Image(systemName: "xmark")
+                        .foregroundColor(.gray)
+                }
+            }
+            .padding()
+            
+            Divider()
+            
+            ScrollView {
+                VStack(spacing: 20) {
+                    // 전체 동의
+                    HStack {
+                        Button {
+                            allAgreed.toggle()
+                            serviceTermsAgreed = allAgreed
+                            privacyPolicyAgreed = allAgreed
+                            ageConfirmationAgreed = allAgreed
+                            marketingAgreed = allAgreed
+                        } label: {
+                            HStack(spacing: 12) {
+                                Image(systemName: allAgreed ? "checkmark.circle.fill" : "circle")
+                                    .font(.title2)
+                                    .foregroundColor(allAgreed ? .blue : .gray)
+                                
+                                Text("전체 동의")
+                                    .font(.headline)
+                            }
+                        }
+                        Spacer()
+                    }
+                    .padding()
+                    .background(Color.gray.opacity(0.1))
+                    .cornerRadius(12)
+                    
+                    // 개별 약관
+                    VStack(spacing: 16) {
+                        TermRow(
+                            isAgreed: $serviceTermsAgreed,
+                            title: "(필수) 서비스 이용약관"
+                        )
+                        
+                        TermRow(
+                            isAgreed: $privacyPolicyAgreed,
+                            title: "(필수) 개인정보 처리방침"
+                        )
+                        
+                        TermRow(
+                            isAgreed: $ageConfirmationAgreed,
+                            title: "(필수) 만 14세 이상입니다"
+                        )
+                        
+                        TermRow(
+                            isAgreed: $marketingAgreed,
+                            title: "(선택) 마케팅 정보 수신 동의"
+                        )
+                    }
+                }
+                .padding()
+            }
+            
+            // 동의 버튼
+            Button {
+                onAgree()
+            } label: {
+                Text("동의하고 시작하기")
+                    .font(.headline)
+                    .foregroundColor(.white)
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 56)
+                    .background(canProceed ? Color.blue : Color.gray)
+                    .cornerRadius(12)
+            }
+            .disabled(!canProceed)
+            .padding()
+        }
+    }
+}
+
+struct TermRow: View {
+    @Binding var isAgreed: Bool
+    let title: String
+    
+    var body: some View {
+        Button {
+            isAgreed.toggle()
+        } label: {
+            HStack(spacing: 12) {
+                Image(systemName: isAgreed ? "checkmark.circle.fill" : "circle")
+                    .foregroundColor(isAgreed ? .blue : .gray)
+                
+                Text(title)
+                    .font(.subheadline)
+                    .foregroundColor(.primary)
+                
+                Spacer()
+            }
+        }
     }
 }

--- a/TeumTeumEat/TeumTeumEat/Features/Login/LoginView.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/Login/LoginView.swift
@@ -1,0 +1,81 @@
+//
+//  LoginView.swift
+//  TeumTeumEat
+//
+//  Created by 임재현 on 12/28/25.
+//
+
+import SwiftUI
+import ComposableArchitecture
+
+struct LoginView: View {
+    let store: StoreOf<LoginFeature>
+    
+    var body: some View {
+        VStack(spacing: 20) {
+            Spacer()
+            
+            Text("TeumTeumEat")
+                .font(.largeTitle)
+                .fontWeight(.bold)
+            
+            Text("간편하게 로그인하고 시작하세요")
+                .font(.subheadline)
+                .foregroundColor(.gray)
+            
+            Spacer()
+            
+            VStack(spacing: 12) {
+                // 카카오 로그인
+                Button {
+                    store.send(.kakaoLoginTapped)
+                } label: {
+                    HStack {
+                        Image(systemName: "message.fill")
+                        Text("카카오로 시작하기")
+                            .fontWeight(.semibold)
+                    }
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 50)
+                    .background(Color.yellow)
+                    .foregroundColor(.black)
+                    .cornerRadius(10)
+                }
+                
+                // 애플 로그인
+                Button {
+                    store.send(.appleLoginTapped)
+                } label: {
+                    HStack {
+                        Image(systemName: "apple.logo")
+                        Text("Apple로 시작하기")
+                            .fontWeight(.semibold)
+                    }
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 50)
+                    .background(Color.black)
+                    .foregroundColor(.white)
+                    .cornerRadius(10)
+                }
+                
+            }
+            .padding(.horizontal, 20)
+            .disabled(store.isLoading)
+            
+            if let errorMessage = store.errorMessage {
+                Text(errorMessage)
+                    .font(.caption)
+                    .foregroundColor(.red)
+                    .padding(.top, 8)
+            }
+            
+            if store.isLoading {
+                ProgressView()
+                    .padding(.top, 20)
+            }
+            
+            Spacer()
+        }
+        .padding()
+    }
+}

--- a/TeumTeumEat/TeumTeumEat/Features/Login/Models/APIResponse.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/Login/Models/APIResponse.swift
@@ -1,0 +1,15 @@
+//
+//  APIResponse.swift
+//  TeumTeumEat
+//
+//  Created by 임재현 on 12/28/25.
+//
+
+import Foundation
+
+struct APIResponse<T: Decodable>: Decodable {
+    let code: String
+    let message: String
+    let details: String?
+    let data: T?
+}

--- a/TeumTeumEat/TeumTeumEat/Features/Login/Models/SocialLoginData.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/Login/Models/SocialLoginData.swift
@@ -10,7 +10,9 @@ import Foundation
 typealias SocialLoginResponse = APIResponse<SocialLoginData>
 
 struct SocialLoginRequest: Encodable {
+    let idToken: String
     let termsAgreed: Bool
+    let name: String
 }
 
 struct SocialLoginData: Decodable {

--- a/TeumTeumEat/TeumTeumEat/Features/Login/Models/SocialLoginData.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/Login/Models/SocialLoginData.swift
@@ -9,8 +9,12 @@ import Foundation
 
 typealias SocialLoginResponse = APIResponse<SocialLoginData>
 
+struct SocialLoginRequest: Encodable {
+    let termsAgreed: Bool
+}
+
 struct SocialLoginData: Decodable {
     let accessToken: String
     let refreshToken: String
-    let isNewUser: Bool?
+    let isOnboardingCompleted: Bool
 }

--- a/TeumTeumEat/TeumTeumEat/Features/Login/Models/SocialLoginData.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/Login/Models/SocialLoginData.swift
@@ -1,0 +1,16 @@
+//
+//  SocialLoginData.swift
+//  TeumTeumEat
+//
+//  Created by 임재현 on 12/28/25.
+//
+
+import Foundation
+
+typealias SocialLoginResponse = APIResponse<SocialLoginData>
+
+struct SocialLoginData: Decodable {
+    let accessToken: String
+    let refreshToken: String
+    let isNewUser: Bool?
+}

--- a/TeumTeumEat/TeumTeumEat/Features/Login/TermsAgreementFeature.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/Login/TermsAgreementFeature.swift
@@ -166,13 +166,16 @@ struct TermsAgreementFeature {
 
 extension TermsAgreementFeature {
     private func loginToServer(idToken: String, termsAgreed: Bool) async throws -> SocialLoginResponse {
-        let url = URL(string: "")!
+        let baseURL = Config.baseURL
+        let endPoint = "/api/v1/auth/oauth/register?provider=KAKAO"
+        let fullURL = baseURL + endPoint
+        
+        let url = URL(string: fullURL)!
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
-        request.setValue("Bearer \(idToken)", forHTTPHeaderField: "Authorization")
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         
-        let body = SocialLoginRequest(termsAgreed: termsAgreed)
+        let body = SocialLoginRequest(idToken: idToken, termsAgreed: termsAgreed, name: "testUser")
         request.httpBody = try JSONEncoder().encode(body)
         
         let (data, _) = try await URLSession.shared.data(for: request)

--- a/TeumTeumEat/TeumTeumEat/Features/Login/TermsAgreementFeature.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/Login/TermsAgreementFeature.swift
@@ -1,0 +1,183 @@
+//
+//  TermsAgreementFeature.swift
+//  TeumTeumEat
+//
+//  Created by 임재현 on 12/28/25.
+//
+
+import SwiftUI
+import ComposableArchitecture
+
+@Reducer
+struct TermsAgreementFeature {
+    @ObservableState
+    struct State: Equatable {
+        var allAgreed = false
+        var serviceTermsAgreed = false      // 서비스 이용약관 (필수)
+        var privacyPolicyAgreed = false     // 개인정보 처리방침 (필수)
+        var ageConfirmationAgreed = false   // 만 14세 이상 (필수)
+        var marketingAgreed = false         // 마케팅 수신 동의 (선택)
+        
+        var idToken: String  // 로그인 재시도용 idToken
+        var isLoading = false
+        var errorMessage: String?
+        
+        var canProceed: Bool {
+            serviceTermsAgreed && privacyPolicyAgreed && ageConfirmationAgreed
+        }
+        
+        init(idToken: String) {
+            self.idToken = idToken
+        }
+    }
+    
+    enum Action: BindableAction {
+        case binding(BindingAction<State>)
+        
+        case allAgreeTapped
+        case serviceTermsTapped
+        case privacyPolicyTapped
+        case ageConfirmationTapped
+        case marketingTapped
+        
+        case showTermsDetail(TermType)
+        case agreeTapped  // 동의하고 시작하기 버튼
+        
+        case signUpResponse(Result<SocialLoginResponse, Error>)
+        case delegate(Delegate)
+        
+        enum TermType {
+            case service
+            case privacy
+        }
+        
+        enum Delegate {
+            case signUpSuccess(accessToken: String, refreshToken: String)
+        }
+    }
+    
+    var body: some ReducerOf<Self> {
+        BindingReducer()
+        
+        Reduce { state, action in
+            switch action {
+            case .binding(\.allAgreed):
+                // 전체 동의 토글
+                state.serviceTermsAgreed = state.allAgreed
+                state.privacyPolicyAgreed = state.allAgreed
+                state.ageConfirmationAgreed = state.allAgreed
+                state.marketingAgreed = state.allAgreed
+                return .none
+                
+            case .binding(\.serviceTermsAgreed),
+                 .binding(\.privacyPolicyAgreed),
+                 .binding(\.ageConfirmationAgreed),
+                 .binding(\.marketingAgreed):
+                // 개별 항목 변경 시 전체 동의 상태 업데이트
+                state.allAgreed = state.serviceTermsAgreed &&
+                                  state.privacyPolicyAgreed &&
+                                  state.ageConfirmationAgreed &&
+                                  state.marketingAgreed
+                return .none
+                
+            case .binding:
+                return .none
+                
+            case .allAgreeTapped:
+                state.allAgreed.toggle()
+                return .send(.binding(.set(\.allAgreed, state.allAgreed)))
+                
+            case .serviceTermsTapped:
+                state.serviceTermsAgreed.toggle()
+                return .send(.binding(.set(\.serviceTermsAgreed, state.serviceTermsAgreed)))
+                
+            case .privacyPolicyTapped:
+                state.privacyPolicyAgreed.toggle()
+                return .send(.binding(.set(\.privacyPolicyAgreed, state.privacyPolicyAgreed)))
+                
+            case .ageConfirmationTapped:
+                state.ageConfirmationAgreed.toggle()
+                return .send(.binding(.set(\.ageConfirmationAgreed, state.ageConfirmationAgreed)))
+                
+            case .marketingTapped:
+                state.marketingAgreed.toggle()
+                return .send(.binding(.set(\.marketingAgreed, state.marketingAgreed)))
+                
+            case .showTermsDetail(let termType):
+                // TODO: Safari나 WebView로 약관 상세 보기
+                print("약관 상세 보기: \(termType)")
+                return .none
+                
+            case .agreeTapped:
+                guard state.canProceed else {
+                    state.errorMessage = "필수 약관에 동의해주세요."
+                    return .none
+                }
+                
+                state.isLoading = true
+                state.errorMessage = nil
+                
+                return .run { [idToken = state.idToken] send in
+                    do {
+                        // termsAgreed: true로 재시도
+                        let response = try await loginToServer(
+                            idToken: idToken,
+                            termsAgreed: true
+                        )
+                        await send(.signUpResponse(.success(response)))
+                    } catch {
+                        await send(.signUpResponse(.failure(error)))
+                    }
+                }
+                
+            case .signUpResponse(.success(let response)):
+                state.isLoading = false
+                
+                if response.code == "OK" {
+                    guard let data = response.data else {
+                        state.errorMessage = "응답 데이터가 없습니다."
+                        return .none
+                    }
+                    
+                    // 토큰 저장
+                    KeyChainManager.shared.saveAccessToken(data.accessToken)
+                    KeyChainManager.shared.saveRefreshToken(data.refreshToken)
+                    
+                    return .send(.delegate(.signUpSuccess(
+                        accessToken: data.accessToken,
+                        refreshToken: data.refreshToken
+                    )))
+                } else {
+                    state.errorMessage = response.message
+                    return .none
+                }
+                
+            case .signUpResponse(.failure(let error)):
+                state.isLoading = false
+                state.errorMessage = error.localizedDescription
+                return .none
+                
+            case .delegate:
+                return .none
+            }
+        }
+    }
+}
+
+extension TermsAgreementFeature {
+    private func loginToServer(idToken: String, termsAgreed: Bool) async throws -> SocialLoginResponse {
+        let url = URL(string: "")!
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(idToken)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        
+        let body = SocialLoginRequest(termsAgreed: termsAgreed)
+        request.httpBody = try JSONEncoder().encode(body)
+        
+        let (data, _) = try await URLSession.shared.data(for: request)
+        let response = try JSONDecoder().decode(SocialLoginResponse.self, from: data)
+        
+        return response
+    }
+}

--- a/TeumTeumEat/TeumTeumEat/Features/Login/TermsAgreementView.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/Login/TermsAgreementView.swift
@@ -1,0 +1,147 @@
+//
+//  TermsAgreementView.swift
+//  TeumTeumEat
+//
+//  Created by 임재현 on 12/28/25.
+//
+
+import SwiftUI
+import ComposableArchitecture
+
+struct TermsAgreementView: View {
+    @Bindable var store: StoreOf<TermsAgreementFeature>
+    
+    var body: some View {
+        VStack(spacing: 0) {
+            // 헤더
+            VStack(spacing: 12) {
+                Text("서비스 이용을 위해")
+                    .font(.title2)
+                    .fontWeight(.bold)
+                
+                Text("약관 동의가 필요해요")
+                    .font(.body)
+                    .foregroundColor(.gray)
+            }
+            .padding(.top, 60)
+            .padding(.bottom, 40)
+            
+            HStack {
+                Button {
+                    store.send(.allAgreeTapped)
+                } label: {
+                    HStack(spacing: 12) {
+                        Image(systemName: store.allAgreed ? "checkmark.circle.fill" : "circle")
+                            .font(.title2)
+                            .foregroundColor(store.allAgreed ? .blue : .gray)
+                        
+                        Text("전체 동의")
+                            .font(.headline)
+                            .foregroundColor(.primary)
+                    }
+                }
+                
+                Spacer()
+            }
+            .padding()
+            .background(Color.gray.opacity(0.1))
+            .cornerRadius(12)
+            .padding(.horizontal, 20)
+            .padding(.bottom, 20)
+            
+            // 개별 약관
+            VStack(spacing: 16) {
+                TermRow(
+                    isAgreed: $store.serviceTermsAgreed,
+                    title: "(필수) 서비스 이용약관",
+                    onTap: { store.send(.serviceTermsTapped) },
+                    onDetailTap: { store.send(.showTermsDetail(.service)) }
+                )
+                
+                TermRow(
+                    isAgreed: $store.privacyPolicyAgreed,
+                    title: "(필수) 개인정보 처리방침",
+                    onTap: { store.send(.privacyPolicyTapped) },
+                    onDetailTap: { store.send(.showTermsDetail(.privacy)) }
+                )
+                
+                TermRow(
+                    isAgreed: $store.ageConfirmationAgreed,
+                    title: "(필수) 만 14세 이상입니다",
+                    onTap: { store.send(.ageConfirmationTapped) },
+                    onDetailTap: nil
+                )
+                
+                TermRow(
+                    isAgreed: $store.marketingAgreed,
+                    title: "(선택) 마케팅 정보 수신 동의",
+                    onTap: { store.send(.marketingTapped) },
+                    onDetailTap: nil
+                )
+            }
+            .padding(.horizontal, 20)
+            
+            Spacer()
+            
+            if let errorMessage = store.errorMessage {
+                Text(errorMessage)
+                    .font(.caption)
+                    .foregroundColor(.red)
+                    .padding(.bottom, 8)
+            }
+            
+            Button {
+                store.send(.agreeTapped)
+            } label: {
+                if store.isLoading {
+                    ProgressView()
+                        .tint(.white)
+                        .frame(maxWidth: .infinity)
+                        .frame(height: 56)
+                } else {
+                    Text("동의하고 시작하기")
+                        .font(.headline)
+                        .foregroundColor(.white)
+                        .frame(maxWidth: .infinity)
+                        .frame(height: 56)
+                }
+            }
+            .background(store.canProceed ? Color.blue : Color.gray)
+            .cornerRadius(12)
+            .padding(.horizontal, 20)
+            .padding(.bottom, 20)
+            .disabled(!store.canProceed || store.isLoading)
+        }
+    }
+}
+
+
+struct TermRow: View {
+    @Binding var isAgreed: Bool
+    let title: String
+    let onTap: () -> Void
+    let onDetailTap: (() -> Void)?
+    
+    var body: some View {
+        HStack(spacing: 12) {
+            Button(action: onTap) {
+                Image(systemName: isAgreed ? "checkmark.circle.fill" : "circle")
+                    .foregroundColor(isAgreed ? .blue : .gray)
+            }
+            
+            Text(title)
+                .font(.subheadline)
+                .foregroundColor(.primary)
+            
+            Spacer()
+            
+            if let onDetailTap = onDetailTap {
+                Button(action: onDetailTap) {
+                    Image(systemName: "chevron.right")
+                        .font(.caption)
+                        .foregroundColor(.gray)
+                }
+            }
+        }
+    }
+}

--- a/TeumTeumEat/TeumTeumEat/Features/Login/TermsAgreementView.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/Login/TermsAgreementView.swift
@@ -8,140 +8,110 @@
 import SwiftUI
 import ComposableArchitecture
 
-struct TermsAgreementView: View {
-    @Bindable var store: StoreOf<TermsAgreementFeature>
-    
-    var body: some View {
-        VStack(spacing: 0) {
-            // 헤더
-            VStack(spacing: 12) {
-                Text("서비스 이용을 위해")
-                    .font(.title2)
-                    .fontWeight(.bold)
-                
-                Text("약관 동의가 필요해요")
-                    .font(.body)
-                    .foregroundColor(.gray)
-            }
-            .padding(.top, 60)
-            .padding(.bottom, 40)
-            
-            HStack {
-                Button {
-                    store.send(.allAgreeTapped)
-                } label: {
-                    HStack(spacing: 12) {
-                        Image(systemName: store.allAgreed ? "checkmark.circle.fill" : "circle")
-                            .font(.title2)
-                            .foregroundColor(store.allAgreed ? .blue : .gray)
-                        
-                        Text("전체 동의")
-                            .font(.headline)
-                            .foregroundColor(.primary)
-                    }
-                }
-                
-                Spacer()
-            }
-            .padding()
-            .background(Color.gray.opacity(0.1))
-            .cornerRadius(12)
-            .padding(.horizontal, 20)
-            .padding(.bottom, 20)
-            
-            // 개별 약관
-            VStack(spacing: 16) {
-                TermRow(
-                    isAgreed: $store.serviceTermsAgreed,
-                    title: "(필수) 서비스 이용약관",
-                    onTap: { store.send(.serviceTermsTapped) },
-                    onDetailTap: { store.send(.showTermsDetail(.service)) }
-                )
-                
-                TermRow(
-                    isAgreed: $store.privacyPolicyAgreed,
-                    title: "(필수) 개인정보 처리방침",
-                    onTap: { store.send(.privacyPolicyTapped) },
-                    onDetailTap: { store.send(.showTermsDetail(.privacy)) }
-                )
-                
-                TermRow(
-                    isAgreed: $store.ageConfirmationAgreed,
-                    title: "(필수) 만 14세 이상입니다",
-                    onTap: { store.send(.ageConfirmationTapped) },
-                    onDetailTap: nil
-                )
-                
-                TermRow(
-                    isAgreed: $store.marketingAgreed,
-                    title: "(선택) 마케팅 정보 수신 동의",
-                    onTap: { store.send(.marketingTapped) },
-                    onDetailTap: nil
-                )
-            }
-            .padding(.horizontal, 20)
-            
-            Spacer()
-            
-            if let errorMessage = store.errorMessage {
-                Text(errorMessage)
-                    .font(.caption)
-                    .foregroundColor(.red)
-                    .padding(.bottom, 8)
-            }
-            
-            Button {
-                store.send(.agreeTapped)
-            } label: {
-                if store.isLoading {
-                    ProgressView()
-                        .tint(.white)
-                        .frame(maxWidth: .infinity)
-                        .frame(height: 56)
-                } else {
-                    Text("동의하고 시작하기")
-                        .font(.headline)
-                        .foregroundColor(.white)
-                        .frame(maxWidth: .infinity)
-                        .frame(height: 56)
-                }
-            }
-            .background(store.canProceed ? Color.blue : Color.gray)
-            .cornerRadius(12)
-            .padding(.horizontal, 20)
-            .padding(.bottom, 20)
-            .disabled(!store.canProceed || store.isLoading)
-        }
-    }
-}
+//struct TermsAgreementView: View {
+//    @Bindable var store: StoreOf<TermsAgreementFeature>
+//    
+//    var body: some View {
+//        VStack(spacing: 0) {
+//            // 헤더
+//            VStack(spacing: 12) {
+//                Text("서비스 이용을 위해")
+//                    .font(.title2)
+//                    .fontWeight(.bold)
+//                
+//                Text("약관 동의가 필요해요")
+//                    .font(.body)
+//                    .foregroundColor(.gray)
+//            }
+//            .padding(.top, 60)
+//            .padding(.bottom, 40)
+//            
+//            HStack {
+//                Button {
+//                    store.send(.allAgreeTapped)
+//                } label: {
+//                    HStack(spacing: 12) {
+//                        Image(systemName: store.allAgreed ? "checkmark.circle.fill" : "circle")
+//                            .font(.title2)
+//                            .foregroundColor(store.allAgreed ? .blue : .gray)
+//                        
+//                        Text("전체 동의")
+//                            .font(.headline)
+//                            .foregroundColor(.primary)
+//                    }
+//                }
+//                
+//                Spacer()
+//            }
+//            .padding()
+//            .background(Color.gray.opacity(0.1))
+//            .cornerRadius(12)
+//            .padding(.horizontal, 20)
+//            .padding(.bottom, 20)
+//            
+//            // 개별 약관
+//            VStack(spacing: 16) {
+//                TermRow(
+//                    isAgreed: $store.serviceTermsAgreed,
+//                    title: "(필수) 서비스 이용약관",
+//                    onTap: { store.send(.serviceTermsTapped) },
+//                    onDetailTap: { store.send(.showTermsDetail(.service)) }
+//                )
+//                
+//                TermRow(
+//                    isAgreed: $store.privacyPolicyAgreed,
+//                    title: "(필수) 개인정보 처리방침",
+//                    onTap: { store.send(.privacyPolicyTapped) },
+//                    onDetailTap: { store.send(.showTermsDetail(.privacy)) }
+//                )
+//                
+//                TermRow(
+//                    isAgreed: $store.ageConfirmationAgreed,
+//                    title: "(필수) 만 14세 이상입니다",
+//                    onTap: { store.send(.ageConfirmationTapped) },
+//                    onDetailTap: nil
+//                )
+//                
+//                TermRow(
+//                    isAgreed: $store.marketingAgreed,
+//                    title: "(선택) 마케팅 정보 수신 동의",
+//                    onTap: { store.send(.marketingTapped) },
+//                    onDetailTap: nil
+//                )
+//            }
+//            .padding(.horizontal, 20)
+//            
+//            Spacer()
+//            
+//            if let errorMessage = store.errorMessage {
+//                Text(errorMessage)
+//                    .font(.caption)
+//                    .foregroundColor(.red)
+//                    .padding(.bottom, 8)
+//            }
+//            
+//            Button {
+//                store.send(.agreeTapped)
+//            } label: {
+//                if store.isLoading {
+//                    ProgressView()
+//                        .tint(.white)
+//                        .frame(maxWidth: .infinity)
+//                        .frame(height: 56)
+//                } else {
+//                    Text("동의하고 시작하기")
+//                        .font(.headline)
+//                        .foregroundColor(.white)
+//                        .frame(maxWidth: .infinity)
+//                        .frame(height: 56)
+//                }
+//            }
+//            .background(store.canProceed ? Color.blue : Color.gray)
+//            .cornerRadius(12)
+//            .padding(.horizontal, 20)
+//            .padding(.bottom, 20)
+//            .disabled(!store.canProceed || store.isLoading)
+//        }
+//    }
+//}
 
-
-struct TermRow: View {
-    @Binding var isAgreed: Bool
-    let title: String
-    let onTap: () -> Void
-    let onDetailTap: (() -> Void)?
-    
-    var body: some View {
-        HStack(spacing: 12) {
-            Button(action: onTap) {
-                Image(systemName: isAgreed ? "checkmark.circle.fill" : "circle")
-                    .foregroundColor(isAgreed ? .blue : .gray)
-            }
-            
-            Text(title)
-                .font(.subheadline)
-                .foregroundColor(.primary)
-            
-            Spacer()
-            
-            if let onDetailTap = onDetailTap {
-                Button(action: onDetailTap) {
-                    Image(systemName: "chevron.right")
-                        .font(.caption)
-                        .foregroundColor(.gray)
-                }
-            }
-        }
-    }
-}

--- a/TeumTeumEat/TeumTeumEat/Features/Login/UserDefaultsManager.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/Login/UserDefaultsManager.swift
@@ -1,0 +1,21 @@
+//
+//  UserDefaultsManager.swift
+//  TeumTeumEat
+//
+//  Created by 임재현 on 12/28/25.
+//
+
+import Foundation
+
+enum UserDefaultsManager {
+    private static let isOnboardingCompletedKey = "isOnboardingCompleted"
+    
+    static var isOnboardingCompleted: Bool {
+        get { UserDefaults.standard.bool(forKey: isOnboardingCompletedKey) }
+        set { UserDefaults.standard.set(newValue, forKey: isOnboardingCompletedKey) }
+    }
+    
+    static func clearAll() {
+        UserDefaults.standard.removeObject(forKey: isOnboardingCompletedKey)
+    }
+}

--- a/TeumTeumEat/TeumTeumEat/Features/Splash/SplashFeature.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/Splash/SplashFeature.swift
@@ -20,7 +20,7 @@ struct SplashFeature {
         case authenticationChecked(AuthState)
         
         enum AuthState {
-            case authenticated // 토큰 있음 + 유효
+            case authenticated(isOnboardingCompleted: Bool)  // 토큰 있음 + 유효
             case unauthenticated // 토근 없음 or 만료
         }
     }
@@ -40,7 +40,8 @@ struct SplashFeature {
                     if let accessToken = KeyChainManager.shared.getAccessToken() {
                         // TODO: 토큰 유효성 검증 API 호출
                         // 일단은 토큰 있으면 유효하다고 가정
-                        await send(.authenticationChecked(.authenticated))
+                        let isOnboardingCompleted = UserDefaultsManager.isOnboardingCompleted
+                        await send(.authenticationChecked(.authenticated(isOnboardingCompleted: isOnboardingCompleted)))
                     } else {
                         await send(.authenticationChecked(.unauthenticated))
                     }

--- a/TeumTeumEat/TeumTeumEat/Features/Splash/SplashFeature.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/Splash/SplashFeature.swift
@@ -16,7 +16,13 @@ struct SplashFeature {
     
     enum Action {
         case onAppear
-        case checkAuthenticationComplete
+        case checkAuthentication
+        case authenticationChecked(AuthState)
+        
+        enum AuthState {
+            case authenticated // 토큰 있음 + 유효
+            case unauthenticated // 토근 없음 or 만료
+        }
     }
     
     var body: some ReducerOf<Self> {
@@ -25,9 +31,22 @@ struct SplashFeature {
             case .onAppear:
                 return .run { send in
                     try await Task.sleep(for: .seconds(2))
-                    await send(.checkAuthenticationComplete)
+                    await send(.checkAuthentication)
                 }
-            case .checkAuthenticationComplete:
+                
+            case .checkAuthentication:
+                return .run { send in
+                    // KeyChain에서 토큰 조회
+                    if let accessToken = KeyChainManager.shared.getAccessToken() {
+                        // TODO: 토큰 유효성 검증 API 호출
+                        // 일단은 토큰 있으면 유효하다고 가정
+                        await send(.authenticationChecked(.authenticated))
+                    } else {
+                        await send(.authenticationChecked(.unauthenticated))
+                    }
+                }
+                
+            case .authenticationChecked:
                 state.isActive = true
                 return .none
             }

--- a/TeumTeumEat/TeumTeumEat/Info.plist
+++ b/TeumTeumEat/TeumTeumEat/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>BASE_URL</key>
+	<string>$(BASE_URL)</string>
 	<key>KAKAO_API_KEY</key>
 	<string>$(KAKAO_API_KEY)</string>
 	<key>KAKAO_NATIVE_APPKEY</key>

--- a/TeumTeumEat/TeumTeumEat/Info.plist
+++ b/TeumTeumEat/TeumTeumEat/Info.plist
@@ -2,6 +2,26 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>KAKAO_API_KEY</key>
+	<string>$(KAKAO_API_KEY)</string>
+	<key>KAKAO_NATIVE_APPKEY</key>
+	<string>$(KAKAO_NATIVE_APPKEY)</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>kakao$(KAKAO_NATIVE_APPKEY)</string>
+			</array>
+		</dict>
+	</array>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>kakaokompassauth</string>
+		<string>kakaolink</string>
+	</array>
 	<key>UIAppFonts</key>
 	<array>
 		<string>Pretendard-SemiBold.otf</string>

--- a/TeumTeumEat/TeumTeumEat/Shared/Extensions/KeyChainManager.swift
+++ b/TeumTeumEat/TeumTeumEat/Shared/Extensions/KeyChainManager.swift
@@ -1,0 +1,105 @@
+//
+//  KeyChainManager.swift
+//  TeumTeumEat
+//
+//  Created by 임재현 on 12/27/25.
+//
+
+import Foundation
+import Security
+
+final class KeyChainManager {
+    static let shared = KeyChainManager()
+    private init() {}
+    
+    private let service = "com.teumtuemeat.app"
+    
+    enum KeyChainKey: String {
+        case accessToken
+        case refreshToken
+    }
+    
+    func save(_ value: String, for key: KeyChainKey) {
+        let data = value.data(using: .utf8)!
+        
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: key.rawValue,
+            kSecValueData as String: data
+        ]
+        
+        SecItemDelete(query as CFDictionary)
+        
+        let status = SecItemAdd(query as CFDictionary, nil)
+        
+        if status == errSecSuccess {
+            print("KeyChain Save Success: \(key.rawValue)")
+        } else {
+            print("KeyChain Save Failed: \(status)")
+        }
+    }
+    
+    func get(for key: KeyChainKey) -> String? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: key.rawValue,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne
+        ]
+        
+        var dataTypeRef: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &dataTypeRef)
+        
+        if status == errSecSuccess,
+           let data = dataTypeRef as? Data,
+           let value = String(data: data, encoding: .utf8) {
+            print("KeyChain Get Success: \(key.rawValue)")
+            return value
+        } else {
+            print("KeyChain Get Failed: \(status)")
+            return nil
+        }
+    }
+    
+    func delete(for key: KeyChainKey) {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: key.rawValue
+        ]
+        
+        let status = SecItemDelete(query as CFDictionary)
+        
+        if status == errSecSuccess {
+            print("KeyChain Delete Success: \(key.rawValue)")
+        } else {
+            print("KeyChain Delete Failed: \(status)")
+        }
+    }
+    
+    func deleteAll() {
+        delete(for: .accessToken)
+        delete(for: .refreshToken)
+        print("KeyChain All Deleted")
+    }
+}
+
+extension KeyChainManager {
+    func saveAccessToken(_ token: String) {
+        save(token, for: .accessToken)
+    }
+    
+    func getAccessToken() -> String? {
+        get(for: .accessToken)
+    }
+    
+    func saveRefreshToken(_ token: String) {
+        save(token, for: .refreshToken)
+    }
+    
+    func getRefreshToken() -> String? {
+        get(for: .refreshToken)
+    }
+}


### PR DESCRIPTION
## 🎫 What is the PR?
소셜 로그인(카카오) 및 회원가입 플로우 구현

## 🎫 Changes
- 카카오 소셜 로그인 SDK 연동 및 구현
- 애플 소셜 로그인 기본 구조 구현 (SDK 연동 예정)
- 회원가입 시 약관 동의 BottomSheet UI 구현
- 로그인/회원가입 API 통신 구현
- 온보딩 완료 여부를 UserDefaults로 로컬 관리
- Splash 화면에서 토큰 및 온보딩 상태 기반 화면 분기 처리
- KeyChain을 통한 토큰 안전 저장 및 관리
- Config 파일을 통한 API Base URL 및 소셜 로그인 키 관리

## 🎫 Thoughts
### 1. 온보딩 완료 여부 관리 방식
- 처음에는 매번 서버 API를 호출하여 온보딩 상태를 확인하는 방식을 고려했으나, 온보딩은 한 번만 수행하는 행위이므로 **UserDefaults로 로컬 관리**하는 것이 더 효율적이라고 판단
- 로그인 성공 시 서버에서 받은 `isOnboardingCompleted` 값을 UserDefaults에 저장하고, 앱 재실행 시 이 값으로 온보딩 화면 표시 여부 결정
- 네트워크 비용 절감 및 빠른 앱 시작 가능

### 2. 약관 동의 화면 구현 방식
- LoginFeature 내부에서 처리하여 불필요한 화면 전환 및 Delegate 로직 제거
- 신규 유저인 경우 `AUTH-006` 에러 응답 시 BottomSheet 표시 → 약관 동의 후 `termsAgreed: true`로 재요청

### 3. Provider 동적 처리
- 카카오/애플 등 소셜 로그인 Provider를 동적으로 처리하기 위해 `SocialProvider` enum 추가
- API 엔드포인트에 Provider 정보를 쿼리 파라미터로 전달: `/api/v1/auth/oauth/register?provider=KAKAO`
- 약관 동의 후 재시도 시에도 Provider 정보를 State에 저장해두고 함께 전달


## 🎫 Screenshot
|    구현 내용    |   화면   |
| :-------------: | :----------: |
| Splash → 로그인 플로우 | <img src = "https://github.com/user-attachments/assets/bb455de6-c448-4e78-932c-e480a09030f9" width ="250"> |

## 🎫 To Reviewers
- `loginToServer` 함수의 디버깅 print문이 많은데, 추후 정리 예정입니다
- 애플 로그인 SDK 연동은 아직 미완성 상태로 `fatalError` 처리되어 있습니다
- Config 파일의 실제 키 값은 `.gitignore`에 추가되어 있으니 로컬에서 직접 설정 필요합니다

## 🖥️ 주요 코드 설명

### `LoginFeature`
- 카카오/애플 로그인 SDK 연동 및 서버 통신 처리
- 신규 유저 감지 시 BottomSheet로 약관 동의 처리
- Provider 정보를 State에 저장하여 약관 동의 후 재시도 시 활용
```swift
case .loginAttempt(let idToken, let provider, let termsAgreed):
    state.pendingIdToken = idToken
    state.pendingProvider = provider
    
    return .run { send in
        let response = try await loginToServer(
            idToken: idToken,
            provider: provider,
            termsAgreed: termsAgreed
        )
        await send(.loginResponse(.success(response)))
    }
```

### `SplashFeature`
- 앱 실행 시 토큰 존재 여부 및 온보딩 완료 여부를 체크하여 적절한 화면으로 분기
```swift
case .checkAuthentication:
    return .run { send in
        if KeyChainManager.shared.getAccessToken() != nil {
            let isOnboardingCompleted = UserDefaultsManager.isOnboardingCompleted
            await send(.authenticationChecked(.authenticated(isOnboardingCompleted: isOnboardingCompleted)))
        } else {
            await send(.authenticationChecked(.unauthenticated))
        }
    }
```

### `UserDefaultsManager`
- 온보딩 완료 여부를 로컬에 저장 및 관리
```swift
enum UserDefaultsManager {
    private static let isOnboardingCompletedKey = "isOnboardingCompleted"
    
    static var isOnboardingCompleted: Bool {
        get { UserDefaults.standard.bool(forKey: isOnboardingCompletedKey) }
        set { UserDefaults.standard.set(newValue, forKey: isOnboardingCompletedKey) }
    }
}
```

### `TermsAgreementBottomSheet`
- 서비스 이용약관, 개인정보 처리방침 등 필수/선택 약관 동의 UI
- 전체 동의 기능 및 개별 약관 동의 체크박스 구현

## ✅ Check List
- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?
- [ ] 전체 변경사항이 500줄을 넘지 않는가? (대규모 작업으로 500줄 초과)

## 🎫 Related Issues
- Resolved: #4 