### PR TITLE
[feat,setting] #4 sign in apple 설정, 애플 로그인 flow 구현

### DIFF
--- a/TeumTeumEat/TeumTeumEat.xcodeproj/project.pbxproj
+++ b/TeumTeumEat/TeumTeumEat.xcodeproj/project.pbxproj
@@ -426,6 +426,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = TeumTeumEat/TeumTeumEat.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
@@ -461,6 +462,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = TeumTeumEat/TeumTeumEat.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;

--- a/TeumTeumEat/TeumTeumEat/Features/Login/LoginFeature.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/Login/LoginFeature.swift
@@ -27,7 +27,9 @@ struct LoginFeature {
     
     enum Action {
         case kakaoLoginTapped
-        case appleLoginTapped
+        
+        case appleLoginSuccess(idToken: String)
+        case appleLoginFailure(Error)
 
         case loginAttempt(idToken: String, provider: SocialProvider, termsAgreed: Bool)
         case loginResponse(Result<SocialLoginResponse, Error>)
@@ -65,18 +67,19 @@ struct LoginFeature {
                     }
                 }
                 
-            case .appleLoginTapped:
-                state.isLoading = true
-                state.errorMessage = nil
+            case .appleLoginSuccess(let idToken):
+                print("애플 로그인 성공 - 서버 로그인 시도")
+                return .send(.loginAttempt(
+                    idToken: idToken,
+                    provider: .appleProvider,
+                    termsAgreed: false
+                ))
                 
-                return .run { send in
-                    do {
-                        let idToken = try await loginWithAppleSDK()
-                        await send(.loginAttempt(idToken: idToken, provider: .appleProvider, termsAgreed: false))
-                    } catch {
-                        await send(.loginResponse(.failure(error)))
-                    }
-                }
+            case .appleLoginFailure(let error):
+                state.isLoading = false
+                state.errorMessage = error.localizedDescription
+                print("애플 로그인 실패: \(error)")
+                return .none
                 
             case .loginAttempt(let idToken,let provider, let termsAgreed):
                 state.isLoading = true
@@ -191,11 +194,6 @@ struct LoginFeature {
 
 extension LoginFeature {
 
-    private func loginWithAppleSDK() async throws -> String {
-        // TODO: Apple SDK 연동
-        fatalError("Apple SDK 연동 필요")
-    }
-    
     private func loginWithKakaoSDK() async throws -> String {
         return try await withCheckedThrowingContinuation { continuation in
             if UserApi.isKakaoTalkLoginAvailable() {

--- a/TeumTeumEat/TeumTeumEat/Features/Login/LoginFeature.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/Login/LoginFeature.swift
@@ -16,6 +16,7 @@ struct LoginFeature {
         var isLoading = false
         var errorMessage: String?
         var pendingIdToken: String?
+        var pendingAuthCode: String?
         var pendingProvider: SocialProvider?
         var showTermsSheet = false
     }
@@ -28,10 +29,10 @@ struct LoginFeature {
     enum Action {
         case kakaoLoginTapped
         
-        case appleLoginSuccess(idToken: String)
+        case appleLoginSuccess(idToken: String, authCode: String?)
         case appleLoginFailure(Error)
 
-        case loginAttempt(idToken: String, provider: SocialProvider, termsAgreed: Bool)
+        case loginAttempt(idToken: String, authCode: String?, provider: SocialProvider, termsAgreed: Bool)
         case loginResponse(Result<SocialLoginResponse, Error>)
         
         case dismissTermsSheet
@@ -60,17 +61,18 @@ struct LoginFeature {
                         print("ID Token: \(kakaoIdToken)")
                         print("Token Length: \(kakaoIdToken.count)")
                         print("서버 로그인 시도 (termsAgreed: false)")
-                        await send(.loginAttempt(idToken: kakaoIdToken, provider: .kakao, termsAgreed: false))
+                        await send(.loginAttempt(idToken: kakaoIdToken, authCode: nil, provider: .kakao, termsAgreed: false))
                     } catch {
                         print("카카오 로그인 전체 실패:", error)
                         await send(.loginResponse(.failure(error)))
                     }
                 }
                 
-            case .appleLoginSuccess(let idToken):
+            case .appleLoginSuccess(let idToken, let authCode):
                 print("애플 로그인 성공 - 서버 로그인 시도")
                 return .send(.loginAttempt(
                     idToken: idToken,
+                    authCode: authCode,
                     provider: .appleProvider,
                     termsAgreed: false
                 ))
@@ -81,10 +83,11 @@ struct LoginFeature {
                 print("애플 로그인 실패: \(error)")
                 return .none
                 
-            case .loginAttempt(let idToken,let provider, let termsAgreed):
+            case .loginAttempt(let idToken,let authCode,let provider, let termsAgreed):
                 state.isLoading = true
                 state.errorMessage = nil
                 state.pendingIdToken = idToken
+                state.pendingAuthCode = authCode
                 state.pendingProvider = provider
                 
                 print("서버 로그인 요청")
@@ -95,6 +98,7 @@ struct LoginFeature {
                     do {
                         let response = try await loginToServer(
                             idToken: idToken,
+                            authCode: authCode,
                             provider: provider,
                             termsAgreed: termsAgreed
                         )
@@ -169,22 +173,23 @@ struct LoginFeature {
                 return .none
                 
             case .agreeTermsTapped:
-                 print("약관 동의 확인 - 재로그인 시도")
-                 state.showTermsSheet = false
-                 
-                 guard let idToken = state.pendingIdToken,
-                       let provider = state.pendingProvider else {
-                     state.errorMessage = "토큰 또는 Provider 정보가 없습니다."
-                     return .none
-                 }
-                 
-                 // termsAgreed: true로 재시도
-                 return .send(.loginAttempt(
-                     idToken: idToken,
-                     provider: provider,
-                     termsAgreed: true
-                 ))
+                print("약관 동의 확인 - 재로그인 시도")
+                state.showTermsSheet = false
                 
+                guard let idToken = state.pendingIdToken,
+                      let provider = state.pendingProvider else {
+                    state.errorMessage = "토큰 또는 Provider 정보가 없습니다."
+                    return .none
+                }
+                
+                let authCode = state.pendingAuthCode
+                
+                return .send(.loginAttempt(
+                    idToken: idToken,
+                    authCode: authCode,
+                    provider: provider,
+                    termsAgreed: true
+                ))
             case .delegate:
                 return .none
             }
@@ -220,7 +225,7 @@ extension LoginFeature {
         }
     }
     
-    private func loginToServer(idToken: String, provider: SocialProvider, termsAgreed: Bool) async throws -> SocialLoginResponse {
+    private func loginToServer(idToken: String, authCode: String?, provider: SocialProvider, termsAgreed: Bool) async throws -> SocialLoginResponse {
         print("서버 API 호출 시작")
         let baseURL = Config.baseURL
         let endPoint = "/api/v1/auth/oauth/register?provider=\(provider.rawValue)"
@@ -234,6 +239,7 @@ extension LoginFeature {
         
         let body = SocialLoginRequest(
             idToken: idToken,
+            authCode: authCode,
             termsAgreed: termsAgreed,
             name: "TestUser"
         )
@@ -265,6 +271,7 @@ extension LoginFeature {
         
         print("Request Body 구조:")
         print("   idToken: \(String(idToken.prefix(30)))... (길이: \(idToken.count))")
+        print("   authCode: \(authCode != nil ? "\(String(authCode!.prefix(30)))... (길이: \(authCode!.count))" : "nil")")
         print("   termsAgreed: \(termsAgreed)")
         print("   name: TestUser")
         
@@ -296,7 +303,6 @@ extension LoginFeature {
             }
         }
 
-    
         print("JSON Decoding")
         let response = try JSONDecoder().decode(SocialLoginResponse.self, from: data)
         

--- a/TeumTeumEat/TeumTeumEat/Features/Login/LoginView.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/Login/LoginView.swift
@@ -108,11 +108,19 @@ struct LoginView: View {
                        let identityTokenData = appleIDCredential.identityToken,
                        let identityToken = String(data: identityTokenData, encoding: .utf8) {
                         
+
+                        var authCode: String? = nil
+                        if let authCodeData = appleIDCredential.authorizationCode,
+                           let code = String(data: authCodeData, encoding: .utf8) {
+                            authCode = code
+                        }
+                        
                         print("애플 로그인 성공")
                         print("Identity Token: \(identityToken)")
+                        print("Authorization Code: \(authCode ?? "없음")")
                         
                         // TCA 액션 전송
-                        store.send(.appleLoginSuccess(idToken: identityToken))
+                        store.send(.appleLoginSuccess(idToken: identityToken, authCode: authCode))
                     }
                     
                 case .failure(let error):

--- a/TeumTeumEat/TeumTeumEat/Features/Login/LoginView.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/Login/LoginView.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 import ComposableArchitecture
+import _AuthenticationServices_SwiftUI
 
 struct LoginView: View {
     let store: StoreOf<LoginFeature>
@@ -26,6 +27,30 @@ struct LoginView: View {
             Spacer()
             
             VStack(spacing: 12) {
+                // 애플 로그인
+                Button(action: {
+                    // 빈 액션 (appleLoginButton이 실제 처리)
+                }) {
+                    HStack {
+                        Image(systemName: "apple.logo")
+                        Text("Apple로 시작하기")
+                            .fontWeight(.semibold)
+                    }
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 50)
+                    .background(Color.black)
+                    .foregroundColor(.white)
+                    .cornerRadius(10)
+                }
+                .buttonStyle(PlainButtonStyle())
+                .disabled(store.isLoading)
+                .overlay(
+                    store.isLoading ? ProgressView().tint(.white) : nil
+                )
+                .overlay {
+                    appleLoginButton
+                }
+                
                 // 카카오 로그인
                 Button {
                     store.send(.kakaoLoginTapped)
@@ -41,25 +66,13 @@ struct LoginView: View {
                     .foregroundColor(.black)
                     .cornerRadius(10)
                 }
-                
-                // 애플 로그인
-                Button {
-                    store.send(.appleLoginTapped)
-                } label: {
-                    HStack {
-                        Image(systemName: "apple.logo")
-                        Text("Apple로 시작하기")
-                            .fontWeight(.semibold)
-                    }
-                    .frame(maxWidth: .infinity)
-                    .frame(height: 50)
-                    .background(Color.black)
-                    .foregroundColor(.white)
-                    .cornerRadius(10)
-                }
+                .buttonStyle(PlainButtonStyle())
+                .disabled(store.isLoading)
+                .overlay(
+                    store.isLoading ? ProgressView() : nil
+                )
             }
             .padding(.horizontal, 20)
-            .disabled(store.isLoading)
             
             if let errorMessage = store.errorMessage {
                 Text(errorMessage)
@@ -68,25 +81,50 @@ struct LoginView: View {
                     .padding(.top, 8)
             }
             
-            if store.isLoading {
-                ProgressView()
-                    .padding(.top, 20)
-            }
-            
             Spacer()
         }
         .padding()
         .sheet(isPresented: .init(
-                    get: { store.showTermsSheet },
-                    set: { _ in store.send(.dismissTermsSheet) }
-                )) {
-                    TermsAgreementBottomSheet(
-                        onAgree: { store.send(.agreeTermsTapped) },
-                        onDismiss: { store.send(.dismissTermsSheet) }
-                    )
-                    .presentationDetents([.medium, .large])
+            get: { store.showTermsSheet },
+            set: { _ in store.send(.dismissTermsSheet) }
+        )) {
+            TermsAgreementBottomSheet(
+                onAgree: { store.send(.agreeTermsTapped) },
+                onDismiss: { store.send(.dismissTermsSheet) }
+            )
+            .presentationDetents([.medium, .large])
+        }
+    }
+    
+    private var appleLoginButton: some View {
+        SignInWithAppleButton(
+            onRequest: { request in
+                request.requestedScopes = [.fullName, .email]
+            },
+            onCompletion: { result in
+                switch result {
+                case .success(let authResults):
+                    if let appleIDCredential = authResults.credential as? ASAuthorizationAppleIDCredential,
+                       let identityTokenData = appleIDCredential.identityToken,
+                       let identityToken = String(data: identityTokenData, encoding: .utf8) {
+                        
+                        print("애플 로그인 성공")
+                        print("Identity Token: \(identityToken)")
+                        
+                        // TCA 액션 전송
+                        store.send(.appleLoginSuccess(idToken: identityToken))
+                    }
+                    
+                case .failure(let error):
+                    print("애플 로그인 실패: \(error)")
+                    store.send(.appleLoginFailure(error))
                 }
             }
+        )
+        .frame(maxWidth: .infinity)
+        .frame(height: 50)
+        .blendMode(.hue)  
+    }
 }
 struct TermsAgreementBottomSheet: View {
     let onAgree: () -> Void

--- a/TeumTeumEat/TeumTeumEat/Features/Login/Models/SocialLoginData.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/Login/Models/SocialLoginData.swift
@@ -11,6 +11,7 @@ typealias SocialLoginResponse = APIResponse<SocialLoginData>
 
 struct SocialLoginRequest: Encodable {
     let idToken: String
+    let authCode: String?
     let termsAgreed: Bool
     let name: String
 }

--- a/TeumTeumEat/TeumTeumEat/Features/Login/TermsAgreementFeature.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/Login/TermsAgreementFeature.swift
@@ -124,7 +124,7 @@ struct TermsAgreementFeature {
                             idToken: idToken,
                             termsAgreed: true
                         )
-                        await send(.signUpResponse(.success(response)))
+                       // await send(.signUpResponse(.success(response)))
                     } catch {
                         await send(.signUpResponse(.failure(error)))
                     }
@@ -165,22 +165,22 @@ struct TermsAgreementFeature {
 }
 
 extension TermsAgreementFeature {
-    private func loginToServer(idToken: String, termsAgreed: Bool) async throws -> SocialLoginResponse {
-        let baseURL = Config.baseURL
-        let endPoint = "/api/v1/auth/oauth/register?provider=KAKAO"
-        let fullURL = baseURL + endPoint
-        
-        let url = URL(string: fullURL)!
-        var request = URLRequest(url: url)
-        request.httpMethod = "POST"
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        
-        let body = SocialLoginRequest(idToken: idToken, termsAgreed: termsAgreed, name: "testUser")
-        request.httpBody = try JSONEncoder().encode(body)
-        
-        let (data, _) = try await URLSession.shared.data(for: request)
-        let response = try JSONDecoder().decode(SocialLoginResponse.self, from: data)
-        
-        return response
+    private func loginToServer(idToken: String, termsAgreed: Bool) async throws  {
+//        let baseURL = Config.baseURL
+//        let endPoint = "/api/v1/auth/oauth/register?provider=KAKAO"
+//        let fullURL = baseURL + endPoint
+//        
+//        let url = URL(string: fullURL)!
+//        var request = URLRequest(url: url)
+//        request.httpMethod = "POST"
+//        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+//        
+//     //   let body = SocialLoginRequest(idToken: idToken, termsAgreed: termsAgreed, name: "testUser")
+//        request.httpBody = try JSONEncoder().encode(body)
+//        
+//        let (data, _) = try await URLSession.shared.data(for: request)
+//        let response = try JSONDecoder().decode(SocialLoginResponse.self, from: data)
+//        
+//        return response
     }
 }

--- a/TeumTeumEat/TeumTeumEat/TeumTeumEat.entitlements
+++ b/TeumTeumEat/TeumTeumEat/TeumTeumEat.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
## 🎫 What is the PR?
애플 소셜 로그인 기능 구현

## 🎫 Changes
- 애플 `SignInWithAppleButton` 연동 및 구현
- 애플 로그인 성공 시 idToken 추출 및 서버 전송
- 애플 로그인 UI를 기존 디자인과 일치하도록 overlay 방식으로 구현
- LoginFeature에 애플 로그인 성공/실패 액션 추가
- 카카오 로그인과 동일한 플로우로 통합 (provider 동적 처리)

## 🎫 Thoughts
### 1. SignInWithAppleButton 커스터마이징
- Apple에서 제공하는 `SignInWithAppleButton`은 디자인 커스터마이징이 제한적
- 기존 프로젝트 방식을 참고하여 커스텀 디자인 버튼 위에 투명한 `SignInWithAppleButton`을 overlay로 배치
- `.blendMode(.hue)`를 사용하여 시각적으로는 커스텀 디자인이 보이지만, 실제 터치는 Apple 버튼이 받도록 구현
- Apple 가이드라인 준수를 위해 버튼 외형은 Apple 스타일과 유사하게 유지

### 2. TCA 통합
- 기존 ViewModel 방식 대신 TCA의 Action 기반으로 변경
- `appleLoginSuccess(idToken:)`, `appleLoginFailure(Error)` 액션 추가
- 카카오 로그인과 동일하게 `loginAttempt` 액션으로 통합하여 provider만 `.appleProvider`로 전달
- SignInWithAppleButton의 completion handler에서 직접 store.send() 호출

### 3. Provider 처리
- 카카오/애플 모두 `SocialProvider` enum으로 관리
- API 엔드포인트: `/api/v1/auth/oauth/register?provider=APPLE`
- 동일한 서버 통신 로직 재사용

## 🎫 Screenshot
|    구현 내용    |   화면   |
| :-------------: | :----------: |
| 애플 로그인 버튼 | <img src = "" width ="250"> |
| 애플 로그인 플로우 | <img src = "" width ="250"> |

## 🎫 To Reviewers


## 🖥️ 주요 코드 설명

### `LoginView - appleLoginButton`
- `SignInWithAppleButton`을 투명하게 처리하고 커스텀 디자인을 overlay로 배치
- completion handler에서 idToken 추출 후 TCA 액션 전송
```swift
private var appleLoginButton: some View {
    SignInWithAppleButton(
        onRequest: { request in
            request.requestedScopes = [.fullName, .email]
        },
        onCompletion: { result in
            switch result {
            case .success(let authResults):
                if let appleIDCredential = authResults.credential as? ASAuthorizationAppleIDCredential,
                   let identityTokenData = appleIDCredential.identityToken,
                   let identityToken = String(data: identityTokenData, encoding: .utf8) {
                    store.send(.appleLoginSuccess(idToken: identityToken))
                }
            case .failure(let error):
                store.send(.appleLoginFailure(error))
            }
        }
    )
    .frame(maxWidth: .infinity)
    .frame(height: 50)
    .blendMode(.overlay)
}
```

### `LoginFeature - 애플 로그인 액션 처리`
- 애플 로그인 성공 시 카카오와 동일하게 `loginAttempt` 액션으로 통합
```swift
case .appleLoginSuccess(let idToken):
    print("애플 로그인 성공 - 서버 로그인 시도")
    return .send(.loginAttempt(
        idToken: idToken,
        provider: .appleProvider,
        termsAgreed: false
    ))
    
case .appleLoginFailure(let error):
    state.isLoading = false
    state.errorMessage = error.localizedDescription
    return .none
```

### `SocialProvider enum`
- 카카오와 애플을 동일한 enum으로 관리
```swift
enum SocialProvider: String {
    case kakao = "KAKAO"
    case appleProvider = "APPLE"
}
```

## ✅ Check List
- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?
- [x] 전체 변경사항이 500줄을 넘지 않는가?

## 🎫 Related Issues
- Resolved: #4 