### PR TITLE
[fix] 다시보지않기 버튼 작동되도록 수정

### DIFF
--- a/TeumTeumEat/TeumTeumEat/Features/APIClient.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/APIClient.swift
@@ -890,3 +890,26 @@ extension APIClient {
 }
 
 
+extension APIClient {
+    /// 퀴즈 가이드 본 것으로 표시
+    func updateQuizGuideSeen() async throws {
+        let response: APIResponse<QuizGuideSeenData> = try await request(
+            endpoint: "/api/v1/user-quizzes/guide",
+            method: .post,
+            requiresAuth: true
+        )
+        
+        print("updateQuizGuideSeen - Response code: \(response.code)")
+        
+        guard response.code == "OK",
+              let data = response.data else {
+            throw APIError.serverError(
+                code: response.code,
+                message: response.message,
+                details: response.details
+            )
+        }
+        
+        print("Quiz guide seen status updated: \(data.isQuizGuideSeen)")
+    }
+}

--- a/TeumTeumEat/TeumTeumEat/Features/MainTab/MainTab/Quiz/QuizGuideFeature.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/MainTab/MainTab/Quiz/QuizGuideFeature.swift
@@ -13,10 +13,14 @@ struct QuizGuideFeature {
     @ObservableState
     struct State: Equatable {
         // 안내 화면 상태
+        var isCheckboxSelected: Bool = false
+        var isSubmitting: Bool = false
     }
     
     enum Action {
+        case checkboxToggled
         case startQuizButtonTapped
+        case updateQuizGuideResponse(Result<Void, Error>)
         case delegate(Delegate)
     }
     
@@ -24,10 +28,42 @@ struct QuizGuideFeature {
         case startQuiz  // 퀴즈 시작
     }
     
+    @Dependency(\.apiClient) var apiClient
+    
     var body: some ReducerOf<Self> {
         Reduce { state, action in
             switch action {
+            case .checkboxToggled:
+                state.isCheckboxSelected.toggle()
+                print("체크박스 토글: \(state.isCheckboxSelected)")
+                return .none
+                
             case .startQuizButtonTapped:
+                // 체크박스가 선택된 경우에만 API 호출
+                if state.isCheckboxSelected {
+                    state.isSubmitting = true
+                    return .run { send in
+                        do {
+                            try await apiClient.updateQuizGuideSeen()
+                            await send(.updateQuizGuideResponse(.success(())))
+                        } catch {
+                            await send(.updateQuizGuideResponse(.failure(error)))
+                        }
+                    }
+                } else {
+                    // 체크박스 미선택 시 바로 퀴즈 시작
+                    return .send(.delegate(.startQuiz))
+                }
+                
+            case .updateQuizGuideResponse(.success):
+                state.isSubmitting = false
+                print("퀴즈 가이드 설정 업데이트 성공")
+                return .send(.delegate(.startQuiz))
+                
+            case .updateQuizGuideResponse(.failure(let error)):
+                state.isSubmitting = false
+                print("퀴즈 가이드 설정 업데이트 실패: \(error)")
+                // 실패해도 퀴즈는 진행
                 return .send(.delegate(.startQuiz))
                 
             case .delegate:

--- a/TeumTeumEat/TeumTeumEat/Features/MainTab/MainTab/Quiz/QuizGuideSeenData.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/MainTab/MainTab/Quiz/QuizGuideSeenData.swift
@@ -1,0 +1,12 @@
+//
+//  QuizGuideSeenData.swift
+//  TeumTeumEat
+//
+//  Created by 임재현 on 1/11/26.
+//
+
+import SwiftUI
+
+struct QuizGuideSeenData: Decodable {
+    let isQuizGuideSeen: Bool
+}

--- a/TeumTeumEat/TeumTeumEat/Features/MainTab/MainTab/Quiz/QuizGuideView.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/MainTab/MainTab/Quiz/QuizGuideView.swift
@@ -113,11 +113,11 @@ struct QuizGuideView: View {
                         // 체크박스
                         HStack(spacing: 8) {
                             Button(action: {
-                              //  store.send(.checkboxToggled)
+                                store.send(.checkboxToggled)
                             }) {
-                                Image(systemName:  "circle")
+                                Image(systemName: store.isCheckboxSelected ? "checkmark.circle.fill" : "circle")
                                     .font(.system(size: 20))
-                                    .foregroundColor(.black)
+                                    .foregroundColor(store.isCheckboxSelected ? .blue : .black)
                             }
                             
                             Text("안내 다시 보지 않기")
@@ -126,7 +126,7 @@ struct QuizGuideView: View {
                             
                             Spacer()
                         }
-                        .padding(.horizontal,16)
+                        .padding(.horizontal, 16)
                         .padding(.top, 16)
                         
                         
@@ -134,15 +134,23 @@ struct QuizGuideView: View {
                         Button(action: {
                             store.send(.startQuizButtonTapped)
                         }) {
-                            Text("퀴즈 풀러가기")
-                                .font(.system(size: 16, weight: .semibold))
-                                .foregroundColor(.white)
-                                .frame(maxWidth: .infinity)
-                                .frame(height: 52)
-                                .background(Color(red: 0.2, green: 0.4, blue: 0.8))
-                                .cornerRadius(12)
+                            HStack {
+                                if store.isSubmitting {
+                                    ProgressView()
+                                        .progressViewStyle(CircularProgressViewStyle(tint: .white))
+                                        .scaleEffect(0.8)
+                                }
+                                Text(store.isSubmitting ? "저장 중..." : "퀴즈 풀러가기")
+                                    .font(.system(size: 16, weight: .semibold))
+                            }
+                            .foregroundColor(.white)
+                            .frame(maxWidth: .infinity)
+                            .frame(height: 52)
+                            .background(Color(red: 0.2, green: 0.4, blue: 0.8))
+                            .cornerRadius(12)
                         }
-                        .padding(.horizontal,16)
+                        .disabled(store.isSubmitting)  // API 호출 중에는 비활성화
+                        .padding(.horizontal, 16)
                     }
                     .background(
                         RoundedRectangle(cornerRadius: 12)


### PR DESCRIPTION
## 🎫 What is the PR?
퀴즈 가이드 화면 체크박스 기능 구현 및 서버 연동

## 🎫 Changes
- QuizGuideFeature에 체크박스 토글 상태 관리 추가
- "안내 다시 보지 않기" 체크박스 UI 구현
- 체크박스 선택 시 서버에 가이드 본 것으로 표시하는 API 연동
- API 호출 중 로딩 상태 관리 추가
- APIClient에 `updateQuizGuideSeen()` 메서드 추가
- QuizGuideSeenData 응답 모델 추가

## 🎫 Thoughts
- **API 실패 처리 전략**: 체크박스를 선택하고 "퀴즈 풀러가기"를 눌렀을 때 API 호출이 실패하더라도 퀴즈는 진행되도록 구현했습니다. 사용자 경험을 해치지 않으면서도 서버에 설정을 저장하려는 시도는 하는 것이 좋다고 판단했습니다.
- **로컬 저장 vs 서버 저장**: 처음에는 UserDefaults를 사용한 로컬 저장을 고려했으나, 서버에서 `isFirstTime` 값을 관리하는 구조이므로 서버에 설정을 저장하는 방식이 더 일관성 있다고 판단했습니다. 이를 통해 디바이스를 바꿔도 설정이 유지되는 장점도 있습니다.
- **의존성 주입**: TCA의 Dependency를 활용하여 APIClient를 주입받아 테스트 가능한 구조로 작성했습니다.

## 🎫 Screenshot
|    구현 내용    |   SE   |   13 mini   |   15 pro   |
| :-------------: | :----------: | :----------: | :----------: |
| 체크박스 토글 & API 연동 | <img src = "" width ="250"> | <img src = "" width ="250"> | <img src = "" width ="250"> |

## 🎫 To Reviewers
- 해당 버튼을 체크한 후, 다음 퀴즈에서 진짜로 나타나지 않는지 확인 부탁드립니다.

## 🖥️ 주요 코드 설명

### `QuizGuideFeature`
- 체크박스 상태 관리 및 API 호출 로직 구현
```swift
case .startQuizButtonTapped:
    // 체크박스가 선택된 경우에만 API 호출
    if state.isCheckboxSelected {
        state.isSubmitting = true
        return .run { send in
            do {
                try await apiClient.updateQuizGuideSeen()
                await send(.updateQuizGuideResponse(.success(())))
            } catch {
                await send(.updateQuizGuideResponse(.failure(error)))
            }
        }
    } else {
        // 체크박스 미선택 시 바로 퀴즈 시작
        return .send(.delegate(.startQuiz))
    }
```

### `APIClient.updateQuizGuideSeen()`
- POST 요청으로 퀴즈 가이드 본 것으로 표시
- Request Body 없이 Authorization 헤더만으로 요청
```swift
func updateQuizGuideSeen() async throws {
    let response: APIResponse<QuizGuideSeenData> = try await request(
        endpoint: "/api/v1/user-quizzes/guide",
        method: .post,
        requiresAuth: true
    )
    
    guard response.code == "OK",
          let data = response.data else {
        throw APIError.serverError(
            code: response.code,
            message: response.message,
            details: response.details
        )
    }
    
    print("Quiz guide seen status updated: \(data.isQuizGuideSeen)")
}
```

### `QuizGuideView`
- 체크박스 UI 및 로딩 상태 표시
```swift
// 체크박스
Button(action: {
    store.send(.checkboxToggled)
}) {
    Image(systemName: store.isCheckboxSelected ? "checkmark.circle.fill" : "circle")
        .font(.system(size: 20))
        .foregroundColor(store.isCheckboxSelected ? .blue : .black)
}

// 퀴즈 시작 버튼
Button(action: {
    store.send(.startQuizButtonTapped)
}) {
    HStack {
        if store.isSubmitting {
            ProgressView()
                .progressViewStyle(CircularProgressViewStyle(tint: .white))
                .scaleEffect(0.8)
        }
        Text(store.isSubmitting ? "저장 중..." : "퀴즈 풀러가기")
            .font(.system(size: 16, weight: .semibold))
    }
    .foregroundColor(.white)
    .frame(maxWidth: .infinity)
    .frame(height: 52)
    .background(Color(red: 0.2, green: 0.4, blue: 0.8))
    .cornerRadius(12)
}
.disabled(store.isSubmitting)
```

## ✅ Check List
- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?
- [x] 전체 변경사항이 500줄을 넘지 않는가?

## 🎫 Related Issues
- Resolved: #32 