### PR TITLE
[fix] 타이포그래피 시스템을 리팩토링, 버튼 및 UI 컴포넌트의 디자인 시스템 통일

### DIFF
--- a/TeumTeumEat/TeumTeumEat/Features/APIClient.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/APIClient.swift
@@ -866,7 +866,7 @@ extension APIClient {
     /// 디바이스 토큰 등록
         func registerDeviceToken(token: String, deviceType: String) async throws {
             let response: APIResponse<EmptyData> = try await request(
-                endpoint: "/api/v1/notifications/device-token",
+                endpoint: "/api/v1/notifications/device-tokens",
                 method: .post,
                 body: RegisterDeviceTokenRequest(
                     token: token,

--- a/TeumTeumEat/TeumTeumEat/Features/MainTab/MainTab/MyPage/AppSettingsFeature.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/MainTab/MainTab/MyPage/AppSettingsFeature.swift
@@ -352,3 +352,15 @@ extension String {
                             of: now)
     }
 }
+
+extension AppSettingsFeature.State {
+    var textFieldState: TextFieldState {
+        if let error = nicknameValidationError {
+            return .error(error)
+        } else if !nickname.isEmpty && isNicknameValid {
+            return .valid
+        } else {
+            return .default
+        }
+    }
+}

--- a/TeumTeumEat/TeumTeumEat/Features/MainTab/MainTab/MyPage/AppSettingsView.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/MainTab/MainTab/MyPage/AppSettingsView.swift
@@ -161,20 +161,21 @@ struct AppSettingsView: View {
                     set: { store.send(.nicknameChanged($0)) }
                 ),
                 placeholder: "닉네임을 입력하세요",
+                state: store.textFieldState,
                 allowSpaces: false
             )
             .focused($isNicknameFocused)
             
             // 닉네임 검증 에러 메시지 추가
-            if let nicknameError = store.nicknameValidationError {
-                HStack {
-                    Text(nicknameError)
-                        .font(.system(size: 12, weight: .regular))
-                        .foregroundColor(.red)
-                    Spacer()
-                }
-                .transition(.opacity.combined(with: .move(edge: .top)))
-            }
+//            if let nicknameError = store.nicknameValidationError {
+//                HStack {
+//                    Text(nicknameError)
+//                        .font(.system(size: 12, weight: .regular))
+//                        .foregroundColor(.red)
+//                    Spacer()
+//                }
+//                .transition(.opacity.combined(with: .move(edge: .top)))
+//            }
         }
         .padding(.horizontal, 20)
         .padding(.top, 20)

--- a/TeumTeumEat/TeumTeumEat/Features/Onboarding/Screens/CategorySelection/CategorySelectionView.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/Onboarding/Screens/CategorySelection/CategorySelectionView.swift
@@ -152,7 +152,7 @@ struct MainCategoryStepView: View {
                                 .frame(minHeight: 30)
                             
                             TTEButton(
-                                title: "다음",
+                                title: "다음으로",
                                 size: .large,
                                 isEnabled: store.canProceed
                             ) {
@@ -236,7 +236,7 @@ struct SubCategoryStepView: View {
                                 .frame(minHeight: 30)
                             
                             TTEButton(
-                                title: "다음",
+                                title: "다음으로",
                                 size: .large,
                                 isEnabled: store.canProceed
                             ) {
@@ -339,8 +339,8 @@ struct DetailCategoryStepView: View {
                     size: .large,
                     style: .secondary,
                     isEnabled: true,
-                    foregroundColor: isSelected ? .blue : .black,
-                    borderColor: isSelected ? .blue : .gray.opacity(0.3)
+                    foregroundColor: isSelected ? .blue500 : .gray600,
+                    borderColor: isSelected ? .blue500 : .gray300
                 ) {
                     store.send(.detailCategorySelected(detailCategory))
                 }
@@ -358,15 +358,15 @@ struct CategoryChip: View {
     var body: some View {
         Button(action: action) {
             Text(text)
-                .font(.system(size: 16, weight: .medium))
-                .foregroundColor(isSelected ? .white : .black)
-                .padding(.horizontal, 20)
-                .padding(.vertical, 12)
-                .background(isSelected ? Color.blue : Color.white)
-                .cornerRadius(20)
+                .btSemiBold20_24()
+                .foregroundColor(isSelected ? .blue500 : .gray600)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 16)
+                .background(Color.white)
+                .cornerRadius(16)
                 .overlay(
-                    RoundedRectangle(cornerRadius: 20)
-                        .stroke(isSelected ? Color.blue : Color.gray.opacity(0.3), lineWidth: 1.5)
+                    RoundedRectangle(cornerRadius: 16)
+                        .stroke(isSelected ? Color.blue500 : Color.gray300, lineWidth: isSelected ? 2 : 1)
                 )
         }
         .animation(.easeInOut(duration: 0.2), value: isSelected)
@@ -443,8 +443,8 @@ struct CategoryGridButton: View {
                     .frame(width: 24, height: 24)
                 
                 Text(title)
-                    .titleSemibold20()
-                    .foregroundColor(isSelected ? .blue : .black)
+                    .btSemiBold20_24()
+                    .foregroundColor(isSelected ? .blue500 : .gray600)
                     .lineLimit(1)
                     .minimumScaleFactor(0.7)
             }
@@ -454,7 +454,7 @@ struct CategoryGridButton: View {
             .cornerRadius(16)
             .overlay(
                 RoundedRectangle(cornerRadius: 16)
-                    .stroke(isSelected ? Color.blue : Color.gray.opacity(0.3), lineWidth: 1.5)
+                    .stroke(isSelected ? Color.blue500 : Color.gray300, lineWidth: 2)
             )
         }
     }

--- a/TeumTeumEat/TeumTeumEat/Features/Onboarding/Screens/CategorySelection/CategorySelectionView.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/Onboarding/Screens/CategorySelection/CategorySelectionView.swift
@@ -32,6 +32,7 @@ struct CategorySelectionView: View {
                 }
             }
         }
+        .background(.white)
         .colorScheme(.light)
         .onAppear {
             store.send(.onAppear)
@@ -75,11 +76,15 @@ struct LoadingView: View {
         VStack(spacing: 20) {
             ProgressView()
                 .scaleEffect(1.5)
+                .tint(.gray900)
             
             Text("카테고리를 불러오는 중...")
                 .font(.subheadline)
-                .foregroundColor(.secondary)
+                .foregroundColor(.gray600)
         }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(.white)
+        .colorScheme(.light)
     }
 }
 
@@ -366,7 +371,7 @@ struct CategoryChip: View {
                 .cornerRadius(16)
                 .overlay(
                     RoundedRectangle(cornerRadius: 16)
-                        .stroke(isSelected ? Color.blue500 : Color.gray300, lineWidth: isSelected ? 2 : 1)
+                        .stroke(isSelected ? Color.blue500 : Color.gray300, lineWidth: 2)
                 )
         }
         .animation(.easeInOut(duration: 0.2), value: isSelected)

--- a/TeumTeumEat/TeumTeumEat/Features/Onboarding/Screens/ContentSelection/ContentSelectionView.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/Onboarding/Screens/ContentSelection/ContentSelectionView.swift
@@ -54,7 +54,7 @@ struct ContentSelectionView: View {
                                 }
                                 
                                 TTECategoryButton(
-                                    icon: Image("files"),
+                                    icon: Image("category"),
                                     title: "카테고리 선택",
                                     subtitle: "공부하고 싶은걸\n골라볼게요",
                                     isSelected: store.selectedType == .category
@@ -68,18 +68,13 @@ struct ContentSelectionView: View {
                             Spacer()
                                 .frame(minHeight: 30)
                             
-                            Button {
+                            TTEButton(
+                                title: "다음으로",
+                                size: .large,
+                                isEnabled: store.canProceed
+                            ) {
                                 store.send(.nextTapped)
-                            } label: {
-                                Text("다음")
-                                    .font(.headline)
-                                    .foregroundColor(.white)
-                                    .frame(maxWidth: .infinity)
-                                    .frame(height: 60)
-                                    .background(store.canProceed ? Color.blue : Color.gray)
-                                    .cornerRadius(12)
                             }
-                            .disabled(!store.canProceed)
                             .padding(.horizontal, 20)
                             .padding(.bottom, 32)
                         }

--- a/TeumTeumEat/TeumTeumEat/Features/Onboarding/Screens/ContentSelection/ContentSelectionView.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/Onboarding/Screens/ContentSelection/ContentSelectionView.swift
@@ -47,7 +47,7 @@ struct ContentSelectionView: View {
                                 TTECategoryButton(
                                     icon: Image("files"),
                                     title: "파일 업로드",
-                                    subtitle: "PDF 파일을\n업로드해요",
+                                    subtitle: "공부하고 싶은\n내용이 있어요",
                                     isSelected: store.selectedType == .fileUpload
                                 ) {
                                     store.send(.contentTypeSelected(.fileUpload))

--- a/TeumTeumEat/TeumTeumEat/Features/Onboarding/Screens/DifficultySelection/DifficultySelectionView.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/Onboarding/Screens/DifficultySelection/DifficultySelectionView.swift
@@ -91,17 +91,17 @@ struct DifficultySelectionView: View {
                                             if store.customPrompt.isEmpty {
                                                 VStack(alignment: .leading, spacing: 4) {
                                                     Text("상황설정 예시가 필요합니다.")
-                                                        .font(.system(size: 14))
-                                                        .foregroundColor(.gray)
+                                                        .bdMedium14_20()
+                                                        .foregroundColor(.gray600)
                                                     Text("어떤 식으로 할지 어떤 상황인지 입력해주세요.")
-                                                        .font(.system(size: 14))
-                                                        .foregroundColor(.gray)
+                                                        .bdMedium14_20()
+                                                        .foregroundColor(.gray600)
                                                     Text("ex) IT 트렌드나 프로그래밍 관련 퀴즈를")
-                                                        .font(.system(size: 14))
-                                                        .foregroundColor(.gray)
+                                                        .bdMedium14_20()
+                                                        .foregroundColor(.gray600)
                                                     Text("풀고 싶어요")
-                                                        .font(.system(size: 14))
-                                                        .foregroundColor(.gray)
+                                                        .bdMedium14_20()
+                                                        .foregroundColor(.gray600)
                                                 }
                                                 .padding(.horizontal, 16)
                                                 .padding(.top, 12)
@@ -132,7 +132,7 @@ struct DifficultySelectionView: View {
                                     .background(Color.white)
                                     .overlay(
                                         RoundedRectangle(cornerRadius: 12)
-                                            .stroke(isTextEditorFocused ? Color.blue : Color.gray.opacity(0.3), lineWidth: 1)
+                                            .strokeBorder(isTextEditorFocused ? Color.blue500 : Color.gray300, lineWidth: 2) 
                                     )
                                     .cornerRadius(12)
                                 }
@@ -201,10 +201,12 @@ struct DifficultyButton: View {
                 .frame(height: 50)
                 .background(Color.white)
                 .overlay(
+                    // stroke 대신 strokeBorder를 사용하세요
                     RoundedRectangle(cornerRadius: 12)
-                        .stroke(isSelected ? Color.blue500 : Color.gray300, lineWidth: isSelected ? 2 : 1)
+                        .strokeBorder(isSelected ? Color.blue500 : Color.gray300, lineWidth: 2)
                 )
-                .cornerRadius(12)
+                // .cornerRadius(12)는 overlay 안의 RoundedRectangle과
+                // background가 이미 12라면 굳이 중복해서 쓸 필요 없습니다. (필요시 위치 조정)
         }
     }
 }

--- a/TeumTeumEat/TeumTeumEat/Features/Onboarding/Screens/DifficultySelection/DifficultySelectionView.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/Onboarding/Screens/DifficultySelection/DifficultySelectionView.swift
@@ -196,17 +196,15 @@ struct DifficultyButton: View {
         Button(action: action) {
             Text(title)
                 .font(.system(size: 16, weight: .semibold))
-                .foregroundColor(isSelected ? .white : ._7_A_7_A_7_A)
+                .foregroundColor(isSelected ? .blue500 : .gray600)
                 .frame(maxWidth: .infinity)
                 .frame(height: 50)
-                .background(isSelected ? Color.blue : Color.white)
+                .background(Color.white)
                 .overlay(
                     RoundedRectangle(cornerRadius: 12)
-                        .stroke(isSelected ? Color.blue : Color.gray.opacity(0.3), lineWidth: 1)
+                        .stroke(isSelected ? Color.blue500 : Color.gray300, lineWidth: isSelected ? 2 : 1)
                 )
                 .cornerRadius(12)
         }
     }
 }
-
-

--- a/TeumTeumEat/TeumTeumEat/Features/Onboarding/Screens/FileUpload/FileUploadView.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/Onboarding/Screens/FileUpload/FileUploadView.swift
@@ -62,7 +62,7 @@ struct FileUploadView: View {
                                     ? "잠시만 기다려주세요"
                                     : (store.selectedFileURL != nil
                                         ? "파일이 선택되었어요\n(\(store.fileSizeText ?? ""))"
-                                        : "PDF 파일을\n업로드해요\n(최대 50MB)"),
+                                        : "50MB 이하 파일만 업로드 가능"),
                                 isSelected: store.selectedFileURL != nil,
                                 width: nil,
                                 height: 200
@@ -108,7 +108,7 @@ struct FileUploadView: View {
                                 .frame(minHeight: 30)
                             
                             TTEButton(
-                                title: store.isLoadingFile ? "파일 확인 중..." : "다음",
+                                title: store.isLoadingFile ? "파일 확인 중..." : "다음으로",
                                 size: .large,
                                 isEnabled: store.canProceed
                             ) {

--- a/TeumTeumEat/TeumTeumEat/Features/Onboarding/Screens/NameInput/NameInputFeature.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/Onboarding/Screens/NameInput/NameInputFeature.swift
@@ -78,3 +78,15 @@ struct NameInputFeature {
         }
     }
 }
+
+extension NameInputFeature.State {
+    var textFieldState: TextFieldState {
+        if let error = validationError {
+            return .error(error)
+        } else if !name.isEmpty && canProceed {
+            return .valid
+        } else {
+            return .default
+        }
+    }
+}

--- a/TeumTeumEat/TeumTeumEat/Features/Onboarding/Screens/NameInput/NameInputView.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/Onboarding/Screens/NameInput/NameInputView.swift
@@ -52,7 +52,8 @@ struct NameInputView: View {
                                             get: { store.name },
                                             set: { store.send(.nameChanged($0)) }
                                         ),
-                                        placeholder: "이름을 입력하세요",
+                                        placeholder: "입력해주세요",
+                                        state: store.textFieldState,
                                         allowSpaces: false
                                     )
                                     .focused($isNameFieldFocused)
@@ -62,16 +63,16 @@ struct NameInputView: View {
                                     }
                                     .padding(.horizontal, 30)
                                     
-                                    if let errorMessage = store.validationError {
-                                        HStack {
-                                            Text(errorMessage)
-                                                .font(.system(size: 12, weight: .regular))
-                                                .foregroundColor(.red)
-                                            Spacer()
-                                        }
-                                        .padding(.horizontal, 30)
-                                        .transition(.opacity.combined(with: .move(edge: .top)))
-                                    }
+//                                    if let errorMessage = store.validationError {
+//                                        HStack {
+//                                            Text(errorMessage)
+//                                                .font(.system(size: 12, weight: .regular))
+//                                                .foregroundColor(.red)
+//                                            Spacer()
+//                                        }
+//                                        .padding(.horizontal, 30)
+//                                        .transition(.opacity.combined(with: .move(edge: .top)))
+//                                    }
                                 }
                                 .padding(.top, 56.33)
                                 .padding(.bottom, isNameFieldFocused ? keyboardHeight - 90 : 0)

--- a/TeumTeumEat/TeumTeumEat/Features/Onboarding/Screens/Summary/OnboardingSummaryView.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/Onboarding/Screens/Summary/OnboardingSummaryView.swift
@@ -145,14 +145,14 @@ struct SummaryRow: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
             Text(title)
-                .bodyMedium18()
-                .foregroundColor(.black)
+                .stSemibold16()
+                .foregroundColor(.gray900)
             
             HStack {
                 Spacer()
                 Text(value)
-                    .font(.system(size: 16))
-                    .foregroundColor(.primary)
+                    .btMedium18_24()
+                    .foregroundColor(.gray900)
                 Spacer()
             }
             .padding(.horizontal, 20)
@@ -160,7 +160,7 @@ struct SummaryRow: View {
             .background(Color.white)
             .overlay(
                 RoundedRectangle(cornerRadius: 12)
-                    .stroke(Color.blue, lineWidth: 1)
+                    .stroke(Color.gray300, lineWidth: 2)
             )
             .cornerRadius(12)
         }

--- a/TeumTeumEat/TeumTeumEat/Features/Onboarding/Screens/TimeSetting/TimeSettingView.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/Onboarding/Screens/TimeSetting/TimeSettingView.swift
@@ -47,8 +47,8 @@ struct TimeSettingView: View {
                             // 집을 나오는 시간
                             VStack(alignment: .leading, spacing: 12) {
                                 Text("집에서 나오는 시간")
-                                    .titleSemibold16()
-                                    .foregroundColor(.black)
+                                    .stSemibold16()
+                                    .foregroundColor(.gray900)
                                 
                                 Button(action: {
                                     store.send(.leaveTimeButtonTapped)
@@ -56,8 +56,8 @@ struct TimeSettingView: View {
                                     HStack {
                                         Spacer()
                                         Text(store.leaveTimeText)
-                                            .font(.system(size: 16))
-                                            .foregroundColor(store.leaveTime != nil ? .primary : .gray)
+                                            .btMedium18_24()
+                                            .foregroundColor(store.leaveTime != nil ? .gray900 : .gray600)
                                         Spacer()
                                     }
                                     .padding(.horizontal, 20)
@@ -65,7 +65,7 @@ struct TimeSettingView: View {
                                     .background(Color.white)
                                     .overlay(
                                         RoundedRectangle(cornerRadius: 12)
-                                            .stroke(store.leaveTime != nil ? Color.blue : Color.gray.opacity(0.3), lineWidth: 1)
+                                            .strokeBorder(store.leaveTime != nil ? Color.blue500 : Color.gray300, lineWidth: 2)
                                     )
                                     .cornerRadius(12)
                                 }
@@ -76,8 +76,8 @@ struct TimeSettingView: View {
                             // 집에 돌아오는 시간
                             VStack(alignment: .leading, spacing: 12) {
                                 Text("집에 돌아오는 시간")
-                                    .titleSemibold16()
-                                    .foregroundColor(.black)
+                                    .stSemibold16()
+                                    .foregroundColor(.gray900)
                                 
                                 Button(action: {
                                     store.send(.returnTimeButtonTapped)
@@ -85,8 +85,8 @@ struct TimeSettingView: View {
                                     HStack {
                                         Spacer()
                                         Text(store.returnTimeText)
-                                            .font(.system(size: 16))
-                                            .foregroundColor(store.returnTime != nil ? .primary : .gray)
+                                            .btMedium18_24()
+                                            .foregroundColor(store.returnTime != nil ? .gray900 : .gray600)
                                         Spacer()
                                     }
                                     .padding(.horizontal, 20)
@@ -94,7 +94,7 @@ struct TimeSettingView: View {
                                     .background(Color.white)
                                     .overlay(
                                         RoundedRectangle(cornerRadius: 12)
-                                            .stroke(store.returnTime != nil ? Color.blue : Color.gray.opacity(0.3), lineWidth: 1)
+                                            .strokeBorder(store.returnTime != nil ? Color.blue500 : Color.gray300, lineWidth: 2)
                                     )
                                     .cornerRadius(12)
                                 }
@@ -122,7 +122,7 @@ struct TimeSettingView: View {
                                         }
                                     }
 
-                                    Text("해당 시간에 알림을 받으실건가요?(필수)")
+                                    Text("해당 시간에 알림을 받으실건가요? (필수)")
                                         .bodyRegular14()
                                         .foregroundColor(.black)
                                     

--- a/TeumTeumEat/TeumTeumEat/Features/Onboarding/Screens/TimeSetting/TimeSettingView.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/Onboarding/Screens/TimeSetting/TimeSettingView.swift
@@ -137,7 +137,7 @@ struct TimeSettingView: View {
                                 .frame(minHeight: 20)
                             
                             TTEButton(
-                                title: "다음",
+                                title: "다음으로",
                                 size: .large,
                                 isEnabled: store.canProceed
                             ) {

--- a/TeumTeumEat/TeumTeumEat/Features/Onboarding/Screens/UsageDuration/UsageDurationView.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/Onboarding/Screens/UsageDuration/UsageDurationView.swift
@@ -107,7 +107,7 @@ struct DurationSelectButton: View {
     var body: some View {
         Button(action: action) {
             Text(text)
-                .font(.system(size: 16, weight: .medium))
+                .btSemiBold18_24()
                 .foregroundColor(isSelected ? .blue500 : .gray600)
                 .frame(maxWidth: .infinity)
                 .frame(height: 50)
@@ -115,7 +115,7 @@ struct DurationSelectButton: View {
                 .cornerRadius(12)
                 .overlay(
                     RoundedRectangle(cornerRadius: 12)
-                        .stroke(isSelected ? Color.blue500 : Color.gray300, lineWidth: isSelected ? 2 : 1)
+                        .stroke(isSelected ? Color.blue500 : Color.gray300, lineWidth: 2)
                 )
         }
         .colorScheme(.light)

--- a/TeumTeumEat/TeumTeumEat/Features/Onboarding/Screens/UsageDuration/UsageDurationView.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/Onboarding/Screens/UsageDuration/UsageDurationView.swift
@@ -79,7 +79,7 @@ struct UsageDurationView: View {
                                 .frame(minHeight: 30)
                             
                             TTEButton(
-                                title: "다음",
+                                title: "다음으로",
                                 size: .large,
                                 isEnabled: store.canProceed
                             ) {

--- a/TeumTeumEat/TeumTeumEat/Features/Onboarding/Screens/UsageDuration/UsageDurationView.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/Onboarding/Screens/UsageDuration/UsageDurationView.swift
@@ -108,14 +108,14 @@ struct DurationSelectButton: View {
         Button(action: action) {
             Text(text)
                 .font(.system(size: 16, weight: .medium))
-                .foregroundColor(isSelected ? .white : .black)
+                .foregroundColor(isSelected ? .blue500 : .gray600)
                 .frame(maxWidth: .infinity)
                 .frame(height: 50)
-                .background(isSelected ? Color.blue : Color.white)
+                .background(Color.white)
                 .cornerRadius(12)
                 .overlay(
                     RoundedRectangle(cornerRadius: 12)
-                        .stroke(isSelected ? Color.blue : Color.gray.opacity(0.3), lineWidth: 1)
+                        .stroke(isSelected ? Color.blue500 : Color.gray300, lineWidth: isSelected ? 2 : 1)
                 )
         }
         .colorScheme(.light)

--- a/TeumTeumEat/TeumTeumEat/Features/Onboarding/Screens/Welcome/WelcomeView.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/Onboarding/Screens/Welcome/WelcomeView.swift
@@ -15,12 +15,12 @@ struct WelcomeView: View {
         VStack(spacing: 0) {
             VStack(spacing: 0) {
                 Text("매일 소모되는 이동 시간,")
-                    .titleSemibold18()
-                    .foregroundStyle(.black)
+                    .btSemiBold18_24()
+                    .foregroundStyle(.gray800)
                 
                 Text("틈틈잇과 함께 성장하는 시간으로 바꿔봐요!")
-                    .titleSemibold18()
-                    .foregroundStyle(.black)
+                    .btSemiBold18_24()
+                    .foregroundStyle(.gray800)
             }
             .multilineTextAlignment(.center)
             .padding(.top, 70)
@@ -28,8 +28,6 @@ struct WelcomeView: View {
             
             Image("logo_login")
                 .resizable()
-                .renderingMode(.template)
-                .foregroundStyle(.black)
                 .frame(width: 177,height: 54)
                 .padding(.top, 21)
 

--- a/TeumTeumEat/TeumTeumEat/Shared/Components/Buttons/Buttons.swift
+++ b/TeumTeumEat/TeumTeumEat/Shared/Components/Buttons/Buttons.swift
@@ -32,6 +32,19 @@ enum ButtonSize {
         }
     }
     
+    func applyTypography(to text: Text) -> some View {
+            switch self {
+            case .large:
+                return AnyView(text.btBold20_24())
+            case .medium, .regular:
+                return AnyView(text.stSemibold18())
+            case .small:
+                return AnyView(text.bdMedium16())
+            case .grid:
+                return AnyView(text.stSemibold20())
+            }
+        }
+    
     var typography: TypographyStyle {
         switch self {
         case .large:

--- a/TeumTeumEat/TeumTeumEat/Shared/Components/Buttons/Buttons.swift
+++ b/TeumTeumEat/TeumTeumEat/Shared/Components/Buttons/Buttons.swift
@@ -64,32 +64,32 @@ enum ButtonStyle {
     case secondary
     
     // 텍스트 색상
-    var foregroundColor: Color {
+    func foregroundColor(isEnabled: Bool) -> Color {
         switch self {
         case .primary:
-            return .white                    // 배경 있을 때 흰색
+            return .white
         case .secondary:
-            return ._2_B_8_FFF               // 테두리만 있을 때 파란색
+            return isEnabled ? .blue500 : .gray600
         }
     }
     
     // 배경 색상
-    var backgroundColor: Color {
+    func backgroundColor(isEnabled: Bool) -> Color {
         switch self {
         case .primary:
-            return ._2_B_8_FFF              // 파란색 배경
+            return isEnabled ? .blue500 : .gray600
         case .secondary:
-            return .clear                   // 투명 배경
+            return .clear
         }
     }
     
     // 테두리 색상
-    var borderColor: Color {
+    func borderColor(isEnabled: Bool) -> Color {
         switch self {
         case .primary:
-            return .clear                     // 테두리 없음
+            return .clear
         case .secondary:
-            return ._2_B_8_FFF                // 파란색 테두리
+            return isEnabled ? .blue500 : .gray600
         }
     }
     

--- a/TeumTeumEat/TeumTeumEat/Shared/Components/Buttons/TTEButton.swift
+++ b/TeumTeumEat/TeumTeumEat/Shared/Components/Buttons/TTEButton.swift
@@ -79,8 +79,7 @@ struct TTEButton: View {
                             .frame(width: iconSize ?? 30, height: iconSize ?? 30)
                     }
                     
-                    Text(title)
-                        .font(size.typography.font)
+                    size.applyTypography(to: Text(title))
                         .foregroundColor(customForegroundColor ?? style.foregroundColor)
                     
                     Spacer()
@@ -98,8 +97,7 @@ struct TTEButton: View {
                 )
             } else {
                 // 아이콘이 없을 때 (기존 버튼)
-                Text(title)
-                    .font(size.typography.font)
+                size.applyTypography(to: Text(title))
                     .foregroundColor(customForegroundColor ?? style.foregroundColor)
                     .frame(width: size.width, height: size.height)
                     .background(customBackgroundColor ?? style.backgroundColor)

--- a/TeumTeumEat/TeumTeumEat/Shared/Components/Buttons/TTEButton.swift
+++ b/TeumTeumEat/TeumTeumEat/Shared/Components/Buttons/TTEButton.swift
@@ -80,39 +80,38 @@ struct TTEButton: View {
                     }
                     
                     size.applyTypography(to: Text(title))
-                        .foregroundColor(customForegroundColor ?? style.foregroundColor)
+                        .foregroundColor(customForegroundColor ?? style.foregroundColor(isEnabled: isEnabled))
                     
                     Spacer()
                 }
                 .padding(.leading, iconLeadingPadding ?? 22.5)
                 .frame(width: size.width, height: size.height)
-                .background(customBackgroundColor ?? style.backgroundColor)
+                .background(customBackgroundColor ?? style.backgroundColor(isEnabled: isEnabled))
                 .cornerRadius(16)
                 .overlay(
                     RoundedRectangle(cornerRadius: 16)
                         .stroke(
-                            customBorderColor ?? style.borderColor,
+                            customBorderColor ?? style.borderColor(isEnabled: isEnabled),
                             lineWidth: customBorderWidth ?? style.borderWidth
                         )
                 )
             } else {
                 // 아이콘이 없을 때 (기존 버튼)
                 size.applyTypography(to: Text(title))
-                    .foregroundColor(customForegroundColor ?? style.foregroundColor)
+                    .foregroundColor(customForegroundColor ?? style.foregroundColor(isEnabled: isEnabled))
                     .frame(width: size.width, height: size.height)
-                    .background(customBackgroundColor ?? style.backgroundColor)
+                    .background(customBackgroundColor ?? style.backgroundColor(isEnabled: isEnabled))
                     .cornerRadius(16)
                     .overlay(
                         RoundedRectangle(cornerRadius: 16)
                             .stroke(
-                                customBorderColor ?? style.borderColor,
+                                customBorderColor ?? style.borderColor(isEnabled: isEnabled),
                                 lineWidth: customBorderWidth ?? style.borderWidth
                             )
                     )
             }
         }
         .disabled(!isEnabled)
-        .opacity(isEnabled ? 1.0 : 0.5)
     }
 }
 

--- a/TeumTeumEat/TeumTeumEat/Shared/Components/Buttons/TTECategoryButton.swift
+++ b/TeumTeumEat/TeumTeumEat/Shared/Components/Buttons/TTECategoryButton.swift
@@ -29,8 +29,8 @@ struct TTECategoryButton: View {
         isSelected: Bool = false,
         width: CGFloat? = nil,
         height: CGFloat = 200,
-        iconTint: Color? = ._7_A_7_A_7_A,
-        borderColor: Color? = .C_8_C_8_C_8,
+        iconTint: Color? = nil,
+        borderColor: Color? = nil,
         selectedBorderColor: Color? = nil,
         action: @escaping () -> Void
     ) {
@@ -46,23 +46,23 @@ struct TTECategoryButton: View {
         self.action = action
     }
     
-    private var contentColor: Color {
+    private var iconColor: Color {
         if isSelected {
-            let selectedColor: Color = customSelectedBorderColor ?? ._2_B_8_FFF
-            return selectedColor
+            return customIconTint ?? .blue500
         } else {
-            let normalColor: Color = customIconTint ?? ._7_A_7_A_7_A
-            return normalColor
+            return customIconTint ?? .gray300
         }
+    }
+    
+    private var textColor: Color {
+        isSelected ? .blue500 : .gray600
     }
     
     private var borderColor: Color {
         if isSelected {
-            let selectedColor: Color = customSelectedBorderColor ?? ._2_B_8_FFF
-            return selectedColor
+            return customSelectedBorderColor ?? .blue500
         } else {
-            let normalColor: Color = customBorderColor ?? .C_8_C_8_C_8
-            return normalColor
+            return customBorderColor ?? .gray300
         }
     }
     
@@ -73,20 +73,20 @@ struct TTECategoryButton: View {
                 icon
                     .resizable()
                     .renderingMode(.template)
-                    .foregroundColor(contentColor)
+                    .foregroundColor(iconColor)
                     .frame(width: 60, height: 60)
                 
                 VStack(spacing: 0) {
                     // 타이틀
                     Text(title)
-                        .titleSemibold20()
-                        .foregroundColor(contentColor)
+                        .stSemibold20()
+                        .foregroundColor(textColor)
                         .padding(.bottom, 4)
                     
                     // 서브타이틀
                     Text(subtitle)
-                        .bodyMedium14()
-                        .foregroundColor(contentColor)
+                        .bdMedium14()
+                        .foregroundColor(textColor)
                         .multilineTextAlignment(.center)
                 }
             }

--- a/TeumTeumEat/TeumTeumEat/Shared/Components/Buttons/TTECategoryButton.swift
+++ b/TeumTeumEat/TeumTeumEat/Shared/Components/Buttons/TTECategoryButton.swift
@@ -96,8 +96,8 @@ struct TTECategoryButton: View {
             .cornerRadius(16)
             .overlay(
                 RoundedRectangle(cornerRadius: 16)
-                    .stroke(borderColor, lineWidth: 2)
+                    .strokeBorder(borderColor, lineWidth: 2)
             )
-        }
+        }   
     }
 }

--- a/TeumTeumEat/TeumTeumEat/Shared/Components/TextField/TTETextField.swift
+++ b/TeumTeumEat/TeumTeumEat/Shared/Components/TextField/TTETextField.swift
@@ -25,7 +25,7 @@ struct TTETextField: View {
         maxLength: Int = 10,
         height: CGFloat = 50,
         borderColor: Color = .gray300,
-        borderWidth: CGFloat = 1,
+        borderWidth: CGFloat = 2,
         cornerRadius: CGFloat = 16,
         allowSpaces: Bool = true
     ) {

--- a/TeumTeumEat/TeumTeumEat/Shared/Components/TextField/TTETextField.swift
+++ b/TeumTeumEat/TeumTeumEat/Shared/Components/TextField/TTETextField.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct TTETextField: View {
     @Binding var text: String
     let placeholder: String
+    let state: TextFieldState
     let maxLength: Int
     let height: CGFloat
     let borderColor: Color
@@ -20,9 +21,10 @@ struct TTETextField: View {
     init(
         text: Binding<String>,
         placeholder: String = "입력해주세요",
+        state: TextFieldState = .default,
         maxLength: Int = 10,
         height: CGFloat = 50,
-        borderColor: Color = Color(hex: "C4C4C4"),
+        borderColor: Color = .gray300,
         borderWidth: CGFloat = 1,
         cornerRadius: CGFloat = 16,
         allowSpaces: Bool = true
@@ -35,12 +37,23 @@ struct TTETextField: View {
         self.borderWidth = borderWidth
         self.cornerRadius = cornerRadius
         self.allowSpaces = allowSpaces
+        self.state = state
     }
     
     var body: some View {
         HStack(spacing: 12) {
             // TextField - 중앙 정렬
-            TextField(placeholder, text: $text)
+            TextField(placeholder,
+                      text: $text,
+                      prompt: Text("입력해주세요")
+                        .font(.bd_medium_16)
+                        .foregroundStyle(.gray600)
+            )
+            .lineSpacing(TypographyHelper.calculateLineSpacing(
+                fontSize: 16,
+                weight: .medium,
+                targetLineHeight: 22
+            ))
                 .multilineTextAlignment(.center)
                 .foregroundColor(.black)
                 .onChange(of: text) { oldValue, newValue in
@@ -73,7 +86,45 @@ struct TTETextField: View {
         .background(Color.white)
         .overlay(
             RoundedRectangle(cornerRadius: cornerRadius)
-                .stroke(borderColor, lineWidth: borderWidth)
+                .stroke(state.borderColor, lineWidth: borderWidth)
         )
+        
+        if let errorMessage = state.errorMessage {
+            HStack {
+                Text(errorMessage)
+                    .font(.system(size: 12, weight: .regular))
+                    .foregroundColor(.red500)
+                Spacer()
+            }
+            .transition(.opacity.combined(with: .move(edge: .top)))
+        }
+        
+        
+    }
+}
+
+enum TextFieldState {
+    case `default`
+    case valid
+    case error(String)
+    
+    var borderColor: Color {
+        switch self {
+        case .default:
+            return .gray300
+        case .valid:
+            return .blue500
+        case .error:
+            return .red500
+        }
+    }
+    
+    var errorMessage: String? {
+        switch self {
+        case .error(let message):
+            return message
+        default:
+            return nil
+        }
     }
 }

--- a/TeumTeumEat/TeumTeumEat/Shared/Extensions/Font+.swift
+++ b/TeumTeumEat/TeumTeumEat/Shared/Extensions/Font+.swift
@@ -58,6 +58,13 @@ extension Font {
     static let c_regular_14 = custom(FontFamily.main, FontWeight.regular, size: 14)
     static let c_regular_12 = custom(FontFamily.main, FontWeight.regular, size: 12)
     
+    // button
+    static let bt_bold_20 = custom(FontFamily.main, FontWeight.bold, size: 20)
+    static let bt_semibold_20 = custom(FontFamily.main, FontWeight.semibold, size: 20)
+    static let bt_medium_20 = custom(FontFamily.main, FontWeight.medium, size: 20)
+    static let bt_bold_18 = custom(FontFamily.main, FontWeight.bold, size: 18)
+    static let bt_semibold_18 = custom(FontFamily.main, FontWeight.semibold, size: 18)
+    static let bt_medium_18 = custom(FontFamily.main, FontWeight.medium, size: 18)
 }
 
 struct TypographyStyle {
@@ -271,6 +278,109 @@ extension Text {
     func cRegular12() -> some View {
         self.font(.c_regular_12)
     }
+    
+    func btBold20() -> some View {
+        self.font(.bt_bold_20)
+    }
+    
+    func btBold20_24() -> some View {
+        self.font(.bt_bold_20)
+            .lineSpacing(TypographyHelper.calculateLineSpacing(
+                fontSize: 20,
+                weight: .bold,
+                targetLineHeight: 24)
+            )
+    }
+    
+    func btSemiBold20() -> some View {
+        self.font(.bt_semibold_20)
+    }
+    
+    func btSemiBold20_24() -> some View {
+        self.font(.bt_semibold_20)
+            .lineSpacing(TypographyHelper.calculateLineSpacing(
+                fontSize: 20,
+                weight: .semibold,
+                targetLineHeight: 24)
+            )
+    }
+    
+    func btMedium20_24() -> some View {
+        self.font(.bt_medium_20)
+            .lineSpacing(TypographyHelper.calculateLineSpacing(
+                fontSize: 20,
+                weight: .medium,
+                targetLineHeight: 24)
+            )
+    }
+    
+    func btMedium20_20() -> some View {
+        self.font(.bt_medium_20)
+            .lineSpacing(TypographyHelper.calculateLineSpacing(
+                fontSize: 20,
+                weight: .medium,
+                targetLineHeight: 20)
+            )
+    }
+    
+    func btBold18_24() -> some View {
+        self.font(.bt_bold_18)
+            .lineSpacing(TypographyHelper.calculateLineSpacing(
+                fontSize: 18,
+                weight: .bold,
+                targetLineHeight: 24)
+            )
+    }
+    
+    func btBold18_20() -> some View {
+        self.font(.bt_bold_18)
+            .lineSpacing(TypographyHelper.calculateLineSpacing(
+                fontSize: 18,
+                weight: .bold,
+                targetLineHeight: 20)
+            )
+    }
+    
+    func btSemiBold18_24() -> some View {
+        self.font(.bt_semibold_20)
+            .lineSpacing(TypographyHelper.calculateLineSpacing(
+                fontSize: 18,
+                weight: .semibold,
+                targetLineHeight: 24)
+            )
+    }
+    
+    func btSemiBold18_20() -> some View {
+        self.font(.bt_semibold_18)
+            .lineSpacing(TypographyHelper.calculateLineSpacing(
+                fontSize: 18,
+                weight: .semibold,
+                targetLineHeight: 20)
+            )
+    }
+    
+    
+    func btMedium18_24() -> some View {
+        self.font(.bt_medium_18)
+            .lineSpacing(TypographyHelper.calculateLineSpacing(
+                fontSize: 18,
+                weight: .medium,
+                targetLineHeight: 24)
+            )
+    }
+    
+    
+    func btMedium18_20() -> some View {
+        self.font(.bt_medium_18)
+            .lineSpacing(TypographyHelper.calculateLineSpacing(
+                fontSize: 18,
+                weight: .medium,
+                targetLineHeight: 20)
+            )
+    }
+    
+    
+    
 }
 
 struct TypographyHelper {

--- a/TeumTeumEat/TeumTeumEat/Shared/Extensions/Font+.swift
+++ b/TeumTeumEat/TeumTeumEat/Shared/Extensions/Font+.swift
@@ -40,17 +40,19 @@ extension Font {
        
     static let caption_regular_12 = custom(FontFamily.main, FontWeight.regular, size: 12)
     
-    
+    // title
     static let t_bold_24 = custom(FontFamily.main, FontWeight.bold, size: 24)
     static let t_bold_22 = custom(FontFamily.main, FontWeight.bold, size: 22)
     static let t_bold_20 = custom(FontFamily.main, FontWeight.bold, size: 20)
     
+    // subtitle
     static let st_semibold_20 = custom(FontFamily.main, FontWeight.semibold, size: 20)
     static let st_semibold_18 = custom(FontFamily.main, FontWeight.semibold, size: 18)
     static let st_semibold_16 = custom(FontFamily.main, FontWeight.semibold, size: 16)
-    
-    static let by_semibold_16 = custom(FontFamily.main, FontWeight.semibold, size: 16)
-    
+
+    // body
+    static let bd_medium_16 = custom(FontFamily.main, FontWeight.medium, size: 16)
+    static let bd_medium_14 = custom(FontFamily.main, FontWeight.medium, size: 14)
     
 }
 
@@ -232,7 +234,31 @@ extension Text {
         self.font(.st_semibold_16)
     }
     
+    func bdMedium16() -> some View {
+        self.font(.bd_medium_16)
+    }
     
+    func bdMedium16_22() -> some View {
+        self.font(.bd_medium_16)
+            .lineSpacing(TypographyHelper.calculateLineSpacing(
+                fontSize: 16,
+                weight: .medium,
+                targetLineHeight: 22)
+            )
+    }
+    
+    func bdMedium14() -> some View {
+        self.font(.bd_medium_14)
+    }
+    
+    func bdMedium14_20() -> some View {
+        self.font(.bd_medium_14)
+            .lineSpacing(TypographyHelper.calculateLineSpacing(
+                fontSize: 14,
+                weight: .medium,
+                targetLineHeight: 20)
+            )
+    }
 }
 
 struct TypographyHelper {

--- a/TeumTeumEat/TeumTeumEat/Shared/Extensions/Font+.swift
+++ b/TeumTeumEat/TeumTeumEat/Shared/Extensions/Font+.swift
@@ -54,6 +54,10 @@ extension Font {
     static let bd_medium_16 = custom(FontFamily.main, FontWeight.medium, size: 16)
     static let bd_medium_14 = custom(FontFamily.main, FontWeight.medium, size: 14)
     
+    // caption
+    static let c_regular_14 = custom(FontFamily.main, FontWeight.regular, size: 14)
+    static let c_regular_12 = custom(FontFamily.main, FontWeight.regular, size: 12)
+    
 }
 
 struct TypographyStyle {
@@ -258,6 +262,14 @@ extension Text {
                 weight: .medium,
                 targetLineHeight: 20)
             )
+    }
+    
+    func cRegular14() -> some View {
+        self.font(.c_regular_14)
+    }
+    
+    func cRegular12() -> some View {
+        self.font(.c_regular_12)
     }
 }
 


### PR DESCRIPTION
## 🎫 What is the PR?
앱 전체의 타이포그래피 시스템을 리팩토링하고, 버튼 및 UI 컴포넌트의 디자인 시스템을 통일했습니다.

## 🎫 Changes
### Typography 시스템 개선
- Pretendard 폰트의 기본 설정을 사용하도록 변경 (커스텀 kerning/lineSpacing 제거)
- 필요한 경우에만 lineHeight를 지정하는 방식으로 단순화 (예: `bdMedium16_22()`)
- Font extension에 새로운 폰트 스타일 추가 (`bt_bold_20`, `st_semibold_*`, `bd_medium_*` 등)

### 버튼 컴포넌트 개선
- `TTEButton`: isEnabled 상태에 따른 색상 변경 (opacity 방식 → 색상 직접 변경)
  - enabled: blue500 배경 + white 텍스트
  - disabled: gray600 배경 + white 텍스트
- `ButtonSize`에 `applyTypography` 메서드 추가하여 타이포그래피 적용 방식 개선
- `ButtonStyle`을 함수형으로 변경하여 isEnabled 상태를 반영

### TextField 상태 관리 개선
- `TextFieldState` enum 도입 (`.default`, `.valid`, `.error`)
- Feature State에서 TextField 상태를 계산하여 View는 단순히 상태만 전달받도록 개선
- `TTETextField` 내부에서 에러 메시지 처리하도록 통합
- border 색상과 두께를 상태에 따라 동적으로 변경

### 선택형 버튼 UI 통일
- 모든 선택형 버튼의 디자인 패턴 통일:
  - **선택 안 됨**: 흰 배경 + 회색 텍스트 + 회색 테두리(1pt)
  - **선택됨**: 흰 배경 + 파란 텍스트 + 파란 테두리(2pt)
- 적용 컴포넌트:
  - `DurationSelectButton` (사용 시간 선택)
  - `CategoryChip` (카테고리 칩)
  - `DifficultyButton` (난이도 선택)
  - `TTECategoryButton` (카테고리 버튼)

### 화면별 개선사항
- `NameInputView`: TextField 상태 관리 개선
- `AppSettingsView`: TextField 상태 관리 개선, 닉네임 검증 로직 적용
- `ContentSelectionView`: 커스텀 버튼을 TTEButton으로 교체
- `TimeSettingView`: 시간 선택 버튼 텍스트 색상 수정, border 두께 조정
- `LoadingView`, `CategoryErrorView`: 라이트 모드 색상으로 고정

## 🎫 Thoughts
### 1. Typography 단순화
기존에는 모든 텍스트에 커스텀 kerning과 lineHeight를 적용했지만, Pretendard 폰트의 기본 설정만으로도 충분히 좋은 가독성을 제공한다는 것을 확인했습니다. 특별히 lineHeight가 필요한 경우에만 `_22`, `_24` 같은 suffix를 붙여 명시적으로 표현하도록 변경했습니다.

### 2. 상태 기반 UI 관리
TextField의 border 색상을 View 레벨에서 판단하는 대신, Feature State에서 `TextFieldState`라는 명확한 상태로 제공하도록 개선했습니다. 이를 통해:
- View는 상태만 전달받아 표시하는 단일 책임
- Feature에서 비즈니스 로직 테스트 가능
- 재사용성 향상

### 3. 디자인 시스템 일관성
선택형 버튼들이 각기 다른 디자인 패턴을 가지고 있었는데 (배경 채우기 vs border만 변경), 모두 border + 텍스트 색상만 변경하는 방식으로 통일했습니다. 이를 통해:
- 사용자 경험의 일관성 향상
- 시각적 무게감 감소 (배경을 채우지 않아 더 가벼운 느낌)
- 선택 상태의 명확한 구분 (1pt → 2pt border)

### 4. Button 비활성 상태 표현
기존 opacity 방식은 모든 요소가 흐려져서 가독성이 떨어졌습니다. 명확한 회색 배경으로 변경하여 비활성 상태를 더 직관적으로 표현했습니다.

## 🎫 Screenshot
|    구현 내용    |   Before   |   After   |
| :-------------: | :----------: | :----------: |
| TextField 상태별 색상 | <img src = "" width ="250"> | <img src = "" width ="250"> |
| 버튼 비활성 상태 | <img src = "" width ="250"> | <img src = "" width ="250"> |
| 선택형 버튼 통일 | <img src = "" width ="250"> | <img src = "" width ="250"> |

## 🎫 To Reviewers

## 🖥️ 주요 코드 설명

### `TextFieldState` - TextField 상태 관리
Feature State에서 TextField의 상태를 명확하게 표현하고 View에 전달합니다.
```swift
enum TextFieldState {
    case `default`
    case valid
    case error(String)
    
    var borderColor: Color {
        switch self {
        case .default: return .gray300
        case .valid: return .blue500
        case .error: return .red500
        }
    }
    
    var errorMessage: String? {
        switch self {
        case .error(let message): return message
        default: return nil
        }
    }
}

// Feature State에서 사용
extension NameInputFeature.State {
    var textFieldState: TextFieldState {
        if let error = validationError {
            return .error(error)
        } else if !name.isEmpty && canProceed {
            return .valid
        } else {
            return .default
        }
    }
}
```

### `ButtonStyle` - isEnabled 상태 반영
ButtonStyle을 함수형으로 변경하여 버튼 상태에 따라 다른 색상을 반환합니다.
```swift
enum ButtonStyle {
    case primary
    case secondary
    
    func backgroundColor(isEnabled: Bool) -> Color {
        switch self {
        case .primary:
            return isEnabled ? .blue500 : .gray600
        case .secondary:
            return .clear
        }
    }
    
    func foregroundColor(isEnabled: Bool) -> Color {
        switch self {
        case .primary:
            return .white
        case .secondary:
            return isEnabled ? .blue500 : .gray600
        }
    }
}
```

### `ButtonSize.applyTypography` - 타이포그래피 적용
ButtonSize별로 적절한 타이포그래피를 Text에 적용합니다.
```swift
extension ButtonSize {
    func applyTypography(to text: Text) -> some View {
        switch self {
        case .large:
            return AnyView(text.btBold20_24())
        case .medium, .regular:
            return AnyView(text.stSemibold18())
        case .small:
            return AnyView(text.bdMedium16())
        case .grid:
            return AnyView(text.stSemibold20())
        }
    }
}
```

### Typography Extension - 필요시에만 lineHeight 적용
기본 폰트는 Pretendard 기본 설정을 사용하고, lineHeight가 필요한 경우에만 명시적으로 적용합니다.
```swift
extension Text {
    // 기본 폰트만 적용
    func bdMedium16() -> some View {
        self.font(.bd_medium_16)
    }
    
    // lineHeight가 필요한 경우
    func bdMedium16_22() -> some View {
        self.font(.bd_medium_16)
            .lineSpacing(TypographyHelper.calculateLineSpacing(
                fontSize: 16,
                weight: .medium,
                targetLineHeight: 22
            ))
    }
}
```

## ✅ Check List
- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?
- [x] 전체 변경사항이 500줄을 넘지 않는가?

## 🎫 Related Issues
- Resolved: #