### PR TITLE
Feat/#46: 카테고리 및 PDF 요약글을 SSE(Server-Sent Events)로 실시간 스트리밍 구현

### DIFF
--- a/TeumTeumEat/TeumTeumEat.xcodeproj/project.pbxproj
+++ b/TeumTeumEat/TeumTeumEat.xcodeproj/project.pbxproj
@@ -470,12 +470,12 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.6;
+				MARKETING_VERSION = 1.0.7;
 				PRODUCT_BUNDLE_IDENTIFIER = com.TeumTeumEat;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -509,12 +509,12 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.6;
+				MARKETING_VERSION = 1.0.7;
 				PRODUCT_BUNDLE_IDENTIFIER = com.TeumTeumEat;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/TeumTeumEat/TeumTeumEat/Features/APIClient.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/APIClient.swift
@@ -1307,14 +1307,20 @@ extension APIClient {
                     }
 
                     print("[SSE Category] 연결 성공 (status \(http.statusCode)), 라인 수신 시작")
+                    print("[SSE Category] Response Headers: \(http.allHeaderFields)")
                     var eventType = ""
                     var eventData = ""
                     var rawBuffer: [String] = []
+                    var lineCount = 0
 
                     for try await line in bytes.lines {
+                        lineCount += 1
+                        print("[SSE Category RAW #\(lineCount)] repr=\(line.debugDescription) bytes=\(line.utf8.count)")
                         if line.isEmpty {
                             // 표준 SSE 빈줄 구분자
+                            print("[SSE Category] --- 빈줄(이벤트 구분자) ---")
                             if !eventType.isEmpty {
+                                print("[SSE Category] dispatch event=\(eventType) data=\(eventData.prefix(120))")
                                 if let event = parseCategorySSEEvent(type: eventType, data: eventData) {
                                     continuation.yield(event)
                                 }
@@ -1324,6 +1330,7 @@ extension APIClient {
                             // 새 event: 라인 도착 → 이전 이벤트를 먼저 flush
                             // 서버가 빈줄 없이 event:/data: 를 연속으로 전송하는 경우 대응
                             if !eventType.isEmpty {
+                                print("[SSE Category] flush (no empty line) event=\(eventType) data=\(eventData.prefix(120))")
                                 if let event = parseCategorySSEEvent(type: eventType, data: eventData) {
                                     continuation.yield(event)
                                 }
@@ -1336,9 +1343,11 @@ extension APIClient {
                             eventData = eventData.isEmpty ? value : eventData + "\n" + value
                         } else {
                             // SSE 형식이 아닌 raw 라인 — JSON 에러 본문일 수 있음
+                            print("[SSE Category] non-SSE line: \(line.prefix(200))")
                             rawBuffer.append(line)
                         }
                     }
+                    print("[SSE Category] 루프 종료 - 수신된 총 라인 수: \(lineCount)")
                     // 마지막 이벤트 처리 (빈줄 없이 스트림이 종료된 경우)
                     if !eventType.isEmpty {
                         if let event = parseCategorySSEEvent(type: eventType, data: eventData) {
@@ -1411,13 +1420,19 @@ extension APIClient {
                     }
 
                     print("[SSE PDF] 연결 성공 (status \(http.statusCode)), 라인 수신 시작")
+                    print("[SSE PDF] Response Headers: \(http.allHeaderFields)")
                     var eventType = ""
                     var eventData = ""
                     var rawBuffer: [String] = []
+                    var lineCount = 0
 
                     for try await line in bytes.lines {
+                        lineCount += 1
+                        print("[SSE PDF RAW #\(lineCount)] repr=\(line.debugDescription) bytes=\(line.utf8.count)")
                         if line.isEmpty {
+                            print("[SSE PDF] --- 빈줄(이벤트 구분자) ---")
                             if !eventType.isEmpty {
+                                print("[SSE PDF] dispatch event=\(eventType) data=\(eventData.prefix(120))")
                                 if let event = parseCategorySSEEvent(type: eventType, data: eventData) {
                                     continuation.yield(event)
                                 }
@@ -1425,6 +1440,7 @@ extension APIClient {
                             }
                         } else if line.hasPrefix("event:") {
                             if !eventType.isEmpty {
+                                print("[SSE PDF] flush (no empty line) event=\(eventType) data=\(eventData.prefix(120))")
                                 if let event = parseCategorySSEEvent(type: eventType, data: eventData) {
                                     continuation.yield(event)
                                 }
@@ -1435,9 +1451,11 @@ extension APIClient {
                             let value = String(line.dropFirst(5))
                             eventData = eventData.isEmpty ? value : eventData + "\n" + value
                         } else {
+                            print("[SSE PDF] non-SSE line: \(line.prefix(200))")
                             rawBuffer.append(line)
                         }
                     }
+                    print("[SSE PDF] 루프 종료 - 수신된 총 라인 수: \(lineCount)")
                     if !eventType.isEmpty {
                         if let event = parseCategorySSEEvent(type: eventType, data: eventData) {
                             continuation.yield(event)

--- a/TeumTeumEat/TeumTeumEat/Features/APIClient.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/APIClient.swift
@@ -1343,7 +1343,7 @@ extension APIClient {
     private func parseCategorySSEEvent(type: String, data: String) -> CategoryStreamEvent? {
         switch type.lowercased() {
         case "connect": return .connected
-        case "message": return data.isEmpty ? nil : .textChunk(data)
+        case "message": return .textChunk(data.isEmpty ? "\n" : data)  // 빈 data = 줄바꿈
         case "title":   return data.isEmpty ? nil : .titleChunk(data)
         default:        return nil
         }

--- a/TeumTeumEat/TeumTeumEat/Features/APIClient.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/APIClient.swift
@@ -655,25 +655,50 @@ extension APIClient {
         return data
     }
     
-    /// PDF(요약글) 조회하기
+    /// PDF 요약글 조회 (없으면 생성 후 재조회)
     func fetchDailyPDFSummary(goalId: Int, documentId: Int) async throws -> PDFSummaryData {
+        let endpoint = "/api/v1/goals/\(goalId)/documents/\(documentId)/summary"
+
+        // Step 1: GET으로 요약글 조회 시도
+        do {
+            let summaryData = try await fetchPDFSummaryGET(endpoint: endpoint)
+            print("[PDFSummary] GET 성공 - documentId: \(summaryData.documentId)")
+            return summaryData
+        } catch let apiError as APIError {
+            if case .serverError(let code, _, _) = apiError, code == "COMMON-005" {
+                print("[PDFSummary] COMMON-005 - 요약글 없음, 생성 시작")
+            } else {
+                throw apiError
+            }
+        }
+
+        // Step 2: 요약글 없음 → POST로 생성
+        let _: APIResponse<EmptyData> = try await request(
+            endpoint: endpoint,
+            method: .post,
+            requiresAuth: true
+        )
+        print("[PDFSummary] POST 생성 완료")
+
+        // Step 3: 생성 후 GET으로 재조회
+        let summaryData = try await fetchPDFSummaryGET(endpoint: endpoint)
+        print("[PDFSummary] GET 재조회 성공 - documentId: \(summaryData.documentId)")
+        return summaryData
+    }
+
+    private func fetchPDFSummaryGET(endpoint: String) async throws -> PDFSummaryData {
         let response: APIResponse<PDFSummaryData> = try await request(
-            endpoint: "/api/v1/goals/\(goalId)/documents/\(documentId)/summary",
+            endpoint: endpoint,
             method: .get,
             requiresAuth: true
         )
-        
-        guard response.code == "OK",
-              let summaryData = response.data else {
+        guard response.code == "OK", let summaryData = response.data else {
             throw APIError.serverError(
                 code: response.code,
                 message: response.message,
                 details: response.details
             )
         }
-
-        print("[PDFSummary] documentId: \(summaryData.documentId), hasSolvedToday: \(summaryData.hasSolvedToday), isFirstTime: \(summaryData.isFirstTime)")
-        
         return summaryData
     }
     
@@ -1140,6 +1165,7 @@ extension APIClient {
                     print("[SSE DEBUG] 이벤트 루프 시작")
 
                     for try await line in bytes.lines {
+                        print("[SSE RAW] \(line)")
                         // 빈 줄 또는 새 id: 가 오면 이전 이벤트 dispatch
                         if line.isEmpty || line.hasPrefix("id:") {
                             if !eventData.isEmpty,
@@ -1160,7 +1186,29 @@ extension APIClient {
                             } else {
                                 eventData += "\n" + value
                             }
+                            // 서버가 COMPLETED/FAILED 후 trailing separator 없이 연결을 유지하는 경우를 대비해
+                            // 데이터가 쌓일 때마다 파싱 시도 → 완성된 JSON이면 즉시 dispatch
+                            if let event = parseSSEEvent(type: eventType, data: eventData) {
+                                if case .completed = event {
+                                    print("[SSE DEBUG] 이벤트 dispatch (즉시): \(eventType) COMPLETED")
+                                    continuation.yield(event)
+                                    continuation.finish()
+                                    return
+                                }
+                                if case .failed = event {
+                                    print("[SSE DEBUG] 이벤트 dispatch (즉시): \(eventType) FAILED")
+                                    continuation.yield(event)
+                                    continuation.finish()
+                                    return
+                                }
+                            }
                         }
+                    }
+                    // 연결 종료 후 버퍼에 남은 이벤트 dispatch (COMPLETED가 마지막일 때)
+                    if !eventData.isEmpty,
+                       let event = parseSSEEvent(type: eventType, data: eventData) {
+                        print("[SSE DEBUG] 이벤트 dispatch (연결 종료 후): \(eventType) / \(eventData.prefix(80))")
+                        continuation.yield(event)
                     }
                     continuation.finish()
                 } catch {

--- a/TeumTeumEat/TeumTeumEat/Features/APIClient.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/APIClient.swift
@@ -708,6 +708,27 @@ extension APIClient {
         return try await fetchPDFSummaryGET(endpoint: "/api/v1/goals/\(goalId)/documents/\(documentId)/summary")
     }
 
+    /// PDF SSE 이후 퀴즈 생성 보장 후 조회
+    /// SSE는 요약글 텍스트만 스트리밍하고 퀴즈는 생성하지 않으므로
+    /// POST /summary 로 퀴즈 생성을 트리거한 뒤 GET quizzes 반환
+    func createAndFetchPDFQuizzes(goalId: Int, documentId: Int) async throws -> [UserQuiz] {
+        let endpoint = "/api/v1/goals/\(goalId)/documents/\(documentId)/summary"
+        do {
+            let _: APIResponse<EmptyData> = try await request(
+                endpoint: endpoint, method: .post, requiresAuth: true
+            )
+            print("[PDFQuizzes] POST 성공 - 퀴즈 생성 완료")
+        } catch let apiError as APIError {
+            if case .serverError(let code, _, _) = apiError, code == "QUIZ-003" {
+                // 이미 생성됨
+                print("[PDFQuizzes] QUIZ-003 - 기존 요약/퀴즈 존재")
+            } else {
+                throw apiError
+            }
+        }
+        return try await fetchUserQuizzes(documentId: documentId, documentType: .document)
+    }
+
     private func fetchPDFSummaryGET(endpoint: String) async throws -> PDFSummaryData {
         let response: APIResponse<PDFSummaryData> = try await request(
             endpoint: endpoint,

--- a/TeumTeumEat/TeumTeumEat/Features/APIClient.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/APIClient.swift
@@ -585,6 +585,23 @@ extension APIClient {
         return statusData
     }
     
+    /// 카테고리 요약글 조회 (GET only — 없으면 COMMON-005 throw, 생성하지 않음)
+    func fetchCategoryDocumentIfExists(categoryId: Int) async throws -> CategoryDocumentData {
+        let response: APIResponse<CategoryDocumentData> = try await request(
+            endpoint: "/api/v1/categories/\(categoryId)/documents/daily",
+            method: .get,
+            requiresAuth: true
+        )
+        guard response.code == "OK", let data = response.data else {
+            throw APIError.serverError(
+                code: response.code,
+                message: response.message,
+                details: response.details
+            )
+        }
+        return data
+    }
+
     /// 오늘의 카테고리 자료(요약글) 조회 (없으면 생성 후 재조회)
     func fetchDailyCategoryDocument(categoryId: Int) async throws -> CategoryDocumentData {
         let dailyEndpoint = "/api/v1/categories/\(categoryId)/documents/daily"
@@ -1216,6 +1233,119 @@ extension APIClient {
                 }
             }
             continuation.onTermination = { _ in task.cancel() }
+        }
+    }
+
+    func streamCategoryDocument(categoryId: Int) -> AsyncThrowingStream<CategoryStreamEvent, Error> {
+        AsyncThrowingStream { continuation in
+            let task = Task {
+                let endpoint = "/api/v1/categories/\(categoryId)/documents/daily/stream"
+                print("[SSE Category] POST 요청 시작: \(Config.baseURL + endpoint)")
+                guard let url = URL(string: Config.baseURL + endpoint) else {
+                    continuation.finish(throwing: APIError.invalidURL); return
+                }
+                var request = URLRequest(url: url)
+                request.httpMethod = "POST"
+                request.setValue("text/event-stream", forHTTPHeaderField: "Accept")
+                request.setValue("0", forHTTPHeaderField: "Content-Length")
+                guard let token = KeyChainManager.shared.getAccessToken() else {
+                    continuation.finish(throwing: APIError.noAccessToken); return
+                }
+                request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+
+                do {
+                    let config = URLSessionConfiguration.default
+                    config.timeoutIntervalForRequest = 300
+                    config.timeoutIntervalForResource = 300
+                    let session = URLSession(configuration: config)
+                    let (bytes, response) = try await session.bytes(for: request)
+                    guard let http = response as? HTTPURLResponse else {
+                        continuation.finish(throwing: APIError.invalidResponse); return
+                    }
+                    if http.statusCode != 200 {
+                        print("[SSE Category] HTTP 오류: \(http.statusCode)")
+                        var data = Data()
+                        for try await byte in bytes { data.append(byte) }
+                        if let err = try? JSONDecoder().decode(SSEErrorResponse.self, from: data) {
+                            print("[SSE Category] 서버 에러: code=\(err.code) message=\(err.message)")
+                            continuation.finish(throwing: APIError.serverError(
+                                code: err.code, message: err.message, details: nil))
+                        } else {
+                            let rawBody = String(data: data, encoding: .utf8) ?? "(decode fail)"
+                            print("[SSE Category] 에러 바디 파싱 실패, raw=\(rawBody.prefix(200))")
+                            continuation.finish(throwing: APIError.serverError(
+                                code: "SSE-\(http.statusCode)",
+                                message: "카테고리 스트림 연결 실패", details: nil))
+                        }
+                        return
+                    }
+
+                    print("[SSE Category] 연결 성공 (status \(http.statusCode)), 라인 수신 시작")
+                    var eventType = ""
+                    var eventData = ""
+                    var rawBuffer: [String] = []
+
+                    for try await line in bytes.lines {
+                        if line.isEmpty {
+                            // 표준 SSE 빈줄 구분자
+                            if !eventType.isEmpty {
+                                if let event = parseCategorySSEEvent(type: eventType, data: eventData) {
+                                    continuation.yield(event)
+                                }
+                                eventType = ""; eventData = ""
+                            }
+                        } else if line.hasPrefix("event:") {
+                            // 새 event: 라인 도착 → 이전 이벤트를 먼저 flush
+                            // 서버가 빈줄 없이 event:/data: 를 연속으로 전송하는 경우 대응
+                            if !eventType.isEmpty {
+                                if let event = parseCategorySSEEvent(type: eventType, data: eventData) {
+                                    continuation.yield(event)
+                                }
+                            }
+                            eventType = String(line.dropFirst(6)).trimmingCharacters(in: .whitespaces)
+                            eventData = ""
+                        } else if line.hasPrefix("data:") {
+                            // leading space 보존: 서버가 단어 앞 공백을 "data: word" 형태로 전송
+                            let value = String(line.dropFirst(5))
+                            eventData = eventData.isEmpty ? value : eventData + "\n" + value
+                        } else {
+                            // SSE 형식이 아닌 raw 라인 — JSON 에러 본문일 수 있음
+                            rawBuffer.append(line)
+                        }
+                    }
+                    // 마지막 이벤트 처리 (빈줄 없이 스트림이 종료된 경우)
+                    if !eventType.isEmpty {
+                        if let event = parseCategorySSEEvent(type: eventType, data: eventData) {
+                            continuation.yield(event)
+                        }
+                    }
+                    // 스트림 본문에 raw JSON 에러가 섞여있는지 확인 (서버가 HTTP 200으로 에러 반환하는 케이스)
+                    let rawBody = rawBuffer.joined(separator: "\n")
+                    if !rawBody.isEmpty,
+                       let bodyData = rawBody.data(using: .utf8),
+                       let err = try? JSONDecoder().decode(SSEErrorResponse.self, from: bodyData) {
+                        print("[SSE Category] 스트림 내 JSON 에러 감지: code=\(err.code) message=\(err.message)")
+                        continuation.finish(throwing: APIError.serverError(
+                            code: err.code, message: err.message, details: nil))
+                    } else {
+                        print("[SSE Category] 스트림 EOF → .completed yield")
+                        continuation.yield(.completed)
+                        continuation.finish()
+                    }
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+            continuation.onTermination = { _ in task.cancel() }
+        }
+    }
+
+    private func parseCategorySSEEvent(type: String, data: String) -> CategoryStreamEvent? {
+        switch type.lowercased() {
+        case "connect": return .connected
+        case "message": return data.isEmpty ? nil : .textChunk(data)
+        case "title":   return data.isEmpty ? nil : .titleChunk(data)
+        default:        return nil
         }
     }
 

--- a/TeumTeumEat/TeumTeumEat/Features/APIClient.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/APIClient.swift
@@ -703,6 +703,11 @@ extension APIClient {
         return summaryData
     }
 
+    /// PDF 요약글 GET only (이미 생성된 것만 반환, 없으면 에러)
+    func fetchPDFSummaryOnly(goalId: Int, documentId: Int) async throws -> PDFSummaryData {
+        return try await fetchPDFSummaryGET(endpoint: "/api/v1/goals/\(goalId)/documents/\(documentId)/summary")
+    }
+
     private func fetchPDFSummaryGET(endpoint: String) async throws -> PDFSummaryData {
         let response: APIResponse<PDFSummaryData> = try await request(
             endpoint: endpoint,
@@ -1329,6 +1334,103 @@ extension APIClient {
                             code: err.code, message: err.message, details: nil))
                     } else {
                         print("[SSE Category] 스트림 EOF → .completed yield")
+                        continuation.yield(.completed)
+                        continuation.finish()
+                    }
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+            continuation.onTermination = { _ in task.cancel() }
+        }
+    }
+
+    func streamPDFSummary(goalId: Int, documentId: Int) -> AsyncThrowingStream<CategoryStreamEvent, Error> {
+        AsyncThrowingStream { continuation in
+            let task = Task {
+                let endpoint = "/api/v1/goals/\(goalId)/documents/\(documentId)/summary/stream"
+                print("[SSE PDF] POST 요청 시작: \(Config.baseURL + endpoint)")
+                guard let url = URL(string: Config.baseURL + endpoint) else {
+                    continuation.finish(throwing: APIError.invalidURL); return
+                }
+                var request = URLRequest(url: url)
+                request.httpMethod = "POST"
+                request.setValue("text/event-stream", forHTTPHeaderField: "Accept")
+                request.setValue("0", forHTTPHeaderField: "Content-Length")
+                guard let token = KeyChainManager.shared.getAccessToken() else {
+                    continuation.finish(throwing: APIError.noAccessToken); return
+                }
+                request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+
+                do {
+                    let config = URLSessionConfiguration.default
+                    config.timeoutIntervalForRequest = 300
+                    config.timeoutIntervalForResource = 300
+                    let session = URLSession(configuration: config)
+                    let (bytes, response) = try await session.bytes(for: request)
+                    guard let http = response as? HTTPURLResponse else {
+                        continuation.finish(throwing: APIError.invalidResponse); return
+                    }
+                    if http.statusCode != 200 {
+                        print("[SSE PDF] HTTP 오류: \(http.statusCode)")
+                        var data = Data()
+                        for try await byte in bytes { data.append(byte) }
+                        if let err = try? JSONDecoder().decode(SSEErrorResponse.self, from: data) {
+                            print("[SSE PDF] 서버 에러: code=\(err.code) message=\(err.message)")
+                            continuation.finish(throwing: APIError.serverError(
+                                code: err.code, message: err.message, details: nil))
+                        } else {
+                            let rawBody = String(data: data, encoding: .utf8) ?? "(decode fail)"
+                            print("[SSE PDF] 에러 바디 파싱 실패, raw=\(rawBody.prefix(200))")
+                            continuation.finish(throwing: APIError.serverError(
+                                code: "SSE-\(http.statusCode)",
+                                message: "PDF 스트림 연결 실패", details: nil))
+                        }
+                        return
+                    }
+
+                    print("[SSE PDF] 연결 성공 (status \(http.statusCode)), 라인 수신 시작")
+                    var eventType = ""
+                    var eventData = ""
+                    var rawBuffer: [String] = []
+
+                    for try await line in bytes.lines {
+                        if line.isEmpty {
+                            if !eventType.isEmpty {
+                                if let event = parseCategorySSEEvent(type: eventType, data: eventData) {
+                                    continuation.yield(event)
+                                }
+                                eventType = ""; eventData = ""
+                            }
+                        } else if line.hasPrefix("event:") {
+                            if !eventType.isEmpty {
+                                if let event = parseCategorySSEEvent(type: eventType, data: eventData) {
+                                    continuation.yield(event)
+                                }
+                            }
+                            eventType = String(line.dropFirst(6)).trimmingCharacters(in: .whitespaces)
+                            eventData = ""
+                        } else if line.hasPrefix("data:") {
+                            let value = String(line.dropFirst(5))
+                            eventData = eventData.isEmpty ? value : eventData + "\n" + value
+                        } else {
+                            rawBuffer.append(line)
+                        }
+                    }
+                    if !eventType.isEmpty {
+                        if let event = parseCategorySSEEvent(type: eventType, data: eventData) {
+                            continuation.yield(event)
+                        }
+                    }
+                    let rawBody = rawBuffer.joined(separator: "\n")
+                    if !rawBody.isEmpty,
+                       let bodyData = rawBody.data(using: .utf8),
+                       let err = try? JSONDecoder().decode(SSEErrorResponse.self, from: bodyData) {
+                        print("[SSE PDF] 스트림 내 JSON 에러 감지: code=\(err.code) message=\(err.message)")
+                        continuation.finish(throwing: APIError.serverError(
+                            code: err.code, message: err.message, details: nil))
+                    } else {
+                        print("[SSE PDF] 스트림 EOF → .completed yield")
                         continuation.yield(.completed)
                         continuation.finish()
                     }

--- a/TeumTeumEat/TeumTeumEat/Features/MainTab/MainTab/Home/HomeFeature.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/MainTab/MainTab/Home/HomeFeature.swift
@@ -23,7 +23,6 @@ struct HomeFeature {
         var currentGoal: GoalResponse?
         var quizStatus: UserQuizStatusData?
         var categoryDocument: CategoryDocumentData?
-        var pdfSummary: PDFSummaryData?
         var quizzes: [UserQuiz] = []
         var calendarData: CalendarHistoryData?
         
@@ -46,12 +45,18 @@ struct HomeFeature {
             guard !isTodayQuizCompleted else { return "done" }
             guard let goal = currentGoal else { return "burger" }
 
-            if goal.type == "CATEGORY", let categoryDoc = categoryDocument {
-                return SnackImageMapper.snackImage(for: categoryDoc.documentId, createdAt: categoryDoc.createdAt)
+            let formatter = DateFormatter()
+            formatter.dateFormat = "yyyy-MM-dd"
+            let today = formatter.string(from: Date())
+
+            if goal.type == "CATEGORY" {
+                let id = goal.category?.categoryId ?? goal.goalId
+                return SnackImageMapper.snackImage(for: id, createdAt: today)
             }
 
-            if goal.type == "DOCUMENT", let pdfSum = pdfSummary {
-                return SnackImageMapper.snackImage(for: pdfSum.documentId, createdAt: pdfSum.createdAt)
+            if goal.type == "DOCUMENT" {
+                let id = goal.documentId ?? goal.goalId
+                return SnackImageMapper.snackImage(for: id, createdAt: today)
             }
 
             return "burger"
@@ -69,10 +74,9 @@ struct HomeFeature {
         // Step 2: 퀴즈 상태 확인
         case fetchQuizStatusResponse(Result<UserQuizStatusData, Error>)
         
-        // Step 3: 요약글 조회 (Goal Type에 따라)
+        // Step 3: 요약글 조회 (카테고리만, PDF는 ContentSummaryFeature가 SSE로 처리)
         case fetchCategoryDocumentResponse(Result<CategoryDocumentData, Error>)
-        case fetchPDFSummaryResponse(Result<PDFSummaryData, Error>)
-        
+
         // Step 4: 퀴즈 조회
         case fetchQuizzesResponse(Result<[UserQuiz], Error>)
         
@@ -171,7 +175,6 @@ struct HomeFeature {
 
                 if isNewGoal {
                     state.categoryDocument = nil
-                    state.pdfSummary = nil
                     state.quizzes = []
                 }
 
@@ -213,7 +216,6 @@ struct HomeFeature {
 
                 if wasCompletedYesterday && !status.hasSolvedToday {
                     state.categoryDocument = nil
-                    state.pdfSummary = nil
                     state.quizzes = []
                 }
                 
@@ -223,52 +225,9 @@ struct HomeFeature {
                     return .none
                 }
                 
-                // Step 3: Goal Type에 따라 요약글 조회
-                if goal.type == "CATEGORY" {
-                    // 카테고리는 ContentSummaryFeature가 SSE로 직접 처리
-                    state.isLoading = false
-                    return .none
-
-                } else if goal.type == "DOCUMENT" {
-                    if let pdfSum = state.pdfSummary {
-                        return .run { [docId = pdfSum.documentId] send in
-                            do {
-                                let quizzes = try await apiClient.fetchUserQuizzes(
-                                    documentId: docId,
-                                    documentType: .document
-                                )
-                                await send(.fetchQuizzesResponse(.success(quizzes)))
-                            } catch {
-                                await send(.fetchQuizzesResponse(.failure(error)))
-                            }
-                        }
-                    }
-                    
-                    // PDF 문서 조회
-                    guard let documentId = goal.documentId else {
-                        state.errorMessage = "문서 ID가 없습니다"
-                        state.isLoading = false
-                        return .none
-                    }
-                    
-                    return .run { [goalId = goal.goalId] send in
-                        do {
-                            let summary = try await apiClient.fetchDailyPDFSummary(
-                                goalId: goalId,
-                                documentId: documentId
-                            )
-                            await send(.fetchPDFSummaryResponse(.success(summary)))
-                        } catch {
-                            await send(.fetchPDFSummaryResponse(.failure(error)))
-                        }
-                    }
-                    
-                } else {
-                    // 알 수 없는 타입
-                    state.errorMessage = "알 수 없는 Goal Type: \(goal.type)"
-                    state.isLoading = false
-                    return .none
-                }
+                // Step 3: CATEGORY/DOCUMENT 모두 ContentSummaryFeature가 SSE로 직접 처리
+                state.isLoading = false
+                return .none
                 
             case .fetchQuizStatusResponse(.failure(let error)):
                 if let apiError = error as? APIError,
@@ -320,36 +279,6 @@ struct HomeFeature {
                 state.isLoading = false
                 state.errorMessage = "카테고리 문서 조회 실패: \(error.localizedDescription)"
                 print("[Home] Step3 실패 (CATEGORY): \(error)")
-                return .none
-                
-            // Step 3-B 완료 (PDF) → Step 4 시작
-            case .fetchPDFSummaryResponse(.success(let summary)):
-                state.pdfSummary = summary
-                print("[Home] Step3 완료 - PDF documentId: \(summary.documentId)")
-                
-                // Step 4: 퀴즈 조회
-                return .run { send in
-                    do {
-                        let quizzes = try await apiClient.fetchUserQuizzes(
-                            documentId: summary.documentId,
-                            documentType: .document
-                        )
-                        await send(.fetchQuizzesResponse(.success(quizzes)))
-                    } catch {
-                        await send(.fetchQuizzesResponse(.failure(error)))
-                    }
-                }
-                
-            case .fetchPDFSummaryResponse(.failure(let error)):
-                if let apiError = error as? APIError,
-                   case .serverError(let code, _, _) = apiError, code == "GOAL-002" {
-                    state.isExpired = true
-                    state.isLoading = false
-                    return .none
-                }
-                state.isLoading = false
-                state.errorMessage = "PDF 요약 조회 실패: \(error.localizedDescription)"
-                print("[Home] Step3 실패 (PDF): \(error)")
                 return .none
                 
             // Step 4 완료
@@ -484,21 +413,19 @@ struct HomeFeature {
                           goal.type == "DOCUMENT",
                           let documentId = goal.documentId {
                     // SSE 스트리밍은 ContentSummaryFeature가 전담
-                    let hasSolvedToday = state.pdfSummary?.hasSolvedToday ?? (state.quizStatus?.hasSolvedToday ?? false)
-                    let isFirstTime = state.pdfSummary?.isFirstTime ?? true
                     let summaryData = ContentSummaryFeature.State(
                         documentId: documentId,
                         summaryText: "",
-                        hasSolvedToday: hasSolvedToday,
-                        isFirstTime: isFirstTime,
+                        hasSolvedToday: state.quizStatus?.hasSolvedToday ?? false,
+                        isFirstTime: true,
                         documentType: .document,
-                        quizzes: state.quizzes,
+                        quizzes: [],
                         goalId: goal.goalId
                     )
                     return .send(.delegate(.startQuizFlow(
-                        quizzes: state.quizzes,
+                        quizzes: [],
                         summaryData: summaryData,
-                        isFirstTime: isFirstTime
+                        isFirstTime: true
                     )))
 
                 } else {

--- a/TeumTeumEat/TeumTeumEat/Features/MainTab/MainTab/Home/HomeFeature.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/MainTab/MainTab/Home/HomeFeature.swift
@@ -480,22 +480,27 @@ struct HomeFeature {
                         isFirstTime: true
                     )))
 
-                } else if let pdfSum = state.pdfSummary {
+                } else if let goal = state.currentGoal,
+                          goal.type == "DOCUMENT",
+                          let documentId = goal.documentId {
+                    // SSE 스트리밍은 ContentSummaryFeature가 전담
+                    let hasSolvedToday = state.pdfSummary?.hasSolvedToday ?? (state.quizStatus?.hasSolvedToday ?? false)
+                    let isFirstTime = state.pdfSummary?.isFirstTime ?? true
                     let summaryData = ContentSummaryFeature.State(
-                        documentId: pdfSum.documentId,
-                        summaryText: pdfSum.summary,
-                        hasSolvedToday: pdfSum.hasSolvedToday,
-                        isFirstTime: pdfSum.isFirstTime,
+                        documentId: documentId,
+                        summaryText: "",
+                        hasSolvedToday: hasSolvedToday,
+                        isFirstTime: isFirstTime,
                         documentType: .document,
-                        quizzes: state.quizzes
+                        quizzes: state.quizzes,
+                        goalId: goal.goalId
                     )
-                    
                     return .send(.delegate(.startQuizFlow(
                         quizzes: state.quizzes,
                         summaryData: summaryData,
-                        isFirstTime: pdfSum.isFirstTime
+                        isFirstTime: isFirstTime
                     )))
-                    
+
                 } else {
                     print("요약 데이터가 아직 없습니다")
                     return .none

--- a/TeumTeumEat/TeumTeumEat/Features/MainTab/MainTab/Home/HomeFeature.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/MainTab/MainTab/Home/HomeFeature.swift
@@ -225,36 +225,10 @@ struct HomeFeature {
                 
                 // Step 3: Goal Type에 따라 요약글 조회
                 if goal.type == "CATEGORY" {
-                    if let categoryDoc = state.categoryDocument {
-                        return .run { [docId = categoryDoc.documentId] send in
-                            do {
-                                let quizzes = try await apiClient.fetchUserQuizzes(
-                                    documentId: docId,
-                                    documentType: .category
-                                )
-                                await send(.fetchQuizzesResponse(.success(quizzes)))
-                            } catch {
-                                await send(.fetchQuizzesResponse(.failure(error)))
-                            }
-                        }
-                    }
-                    
-                    // 카테고리 문서 조회
-                    guard let categoryId = goal.category?.categoryId else {
-                        state.errorMessage = "카테고리 ID가 없습니다"
-                        state.isLoading = false
-                        return .none
-                    }
-                    
-                    return .run { send in
-                        do {
-                            let document = try await apiClient.fetchDailyCategoryDocument(categoryId: categoryId)
-                            await send(.fetchCategoryDocumentResponse(.success(document)))
-                        } catch {
-                            await send(.fetchCategoryDocumentResponse(.failure(error)))
-                        }
-                    }
-                    
+                    // 카테고리는 ContentSummaryFeature가 SSE로 직접 처리
+                    state.isLoading = false
+                    return .none
+
                 } else if goal.type == "DOCUMENT" {
                     if let pdfSum = state.pdfSummary {
                         return .run { [docId = pdfSum.documentId] send in
@@ -328,10 +302,20 @@ struct HomeFeature {
                 
             case .fetchCategoryDocumentResponse(.failure(let error)):
                 if let apiError = error as? APIError,
-                   case .serverError(let code, _, _) = apiError, code == "GOAL-002" {
-                    state.isExpired = true
-                    state.isLoading = false
-                    return .none
+                   case .serverError(let code, _, _) = apiError {
+                    if code == "GOAL-002" {
+                        state.isExpired = true
+                        state.isLoading = false
+                        return .none
+                    }
+                    if code == "COMMON-005" {
+                        // 오늘 문서가 아직 없음 — ContentSummaryFeature가 SSE로 생성
+                        print("[Home] Step3 - 카테고리 문서 없음, SSE에서 생성 예정")
+                        state.categoryDocument = nil
+                        state.quizzes = []
+                        state.isLoading = false
+                        return .none
+                    }
                 }
                 state.isLoading = false
                 state.errorMessage = "카테고리 문서 조회 실패: \(error.localizedDescription)"
@@ -477,22 +461,25 @@ struct HomeFeature {
                     return .none
                 }
                 
-                if let categoryDoc = state.categoryDocument {
+                if let goal = state.currentGoal,
+                   goal.type == "CATEGORY",
+                   let categoryId = goal.category?.categoryId {
+                    // SSE 스트리밍은 ContentSummaryFeature가 전담
                     let summaryData = ContentSummaryFeature.State(
-                        documentId: categoryDoc.documentId,
-                        summaryText: categoryDoc.content,
-                        hasSolvedToday: categoryDoc.hasSolvedToday,
-                        isFirstTime: categoryDoc.isFirstTime,
+                        documentId: 0,
+                        summaryText: "",
+                        hasSolvedToday: state.quizStatus?.hasSolvedToday ?? false,
+                        isFirstTime: true,
                         documentType: .category,
-                        quizzes: state.quizzes
+                        quizzes: [],
+                        categoryId: categoryId
                     )
-                    
                     return .send(.delegate(.startQuizFlow(
-                        quizzes: state.quizzes,
+                        quizzes: [],
                         summaryData: summaryData,
-                        isFirstTime: categoryDoc.isFirstTime
+                        isFirstTime: true
                     )))
-                    
+
                 } else if let pdfSum = state.pdfSummary {
                     let summaryData = ContentSummaryFeature.State(
                         documentId: pdfSum.documentId,

--- a/TeumTeumEat/TeumTeumEat/Features/MainTab/MainTab/Quiz/ContentSummaryFeature.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/MainTab/MainTab/Quiz/ContentSummaryFeature.swift
@@ -180,13 +180,14 @@ struct ContentSummaryFeature {
                         await send(.fetchDocumentMetaCompleted(result))
                     }
                 } else if state.documentType == .document {
-                    // PDF: documentId 이미 알고있으므로 바로 퀴즈 조회
+                    // PDF: SSE는 텍스트만 스트리밍, 퀴즈는 POST /summary 로 생성 필요
                     guard state.quizzes.isEmpty else { return .none }
                     state.isQuizLoading = true
+                    guard let goalId = state.goalId else { return .none }
                     let docId = state.documentId
                     return .run { send in
                         let result = await Result {
-                            try await apiClient.fetchUserQuizzes(documentId: docId, documentType: .document)
+                            try await apiClient.createAndFetchPDFQuizzes(goalId: goalId, documentId: docId)
                         }
                         await send(.fetchQuizzesCompleted(result))
                     }
@@ -232,6 +233,7 @@ struct ContentSummaryFeature {
                 state.isStreaming = true
                 // quizzes가 없으면 타이핑 중에 병렬로 조회
                 let needsQuizzesC = state.quizzes.isEmpty
+                if needsQuizzesC { state.isQuizLoading = true }
                 let docIdC = doc.documentId
                 return .run { send in
                     let chars = Array(doc.content)
@@ -271,6 +273,7 @@ struct ContentSummaryFeature {
                 state.streamingText = ""
                 state.isStreaming = true
                 let needsQuizzesP = state.quizzes.isEmpty
+                if needsQuizzesP { state.isQuizLoading = true }
                 let docIdP = summary.documentId
                 return .run { send in
                     let chars = Array(summary.summary)

--- a/TeumTeumEat/TeumTeumEat/Features/MainTab/MainTab/Quiz/ContentSummaryFeature.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/MainTab/MainTab/Quiz/ContentSummaryFeature.swift
@@ -19,14 +19,22 @@ struct ContentSummaryFeature {
         var documentType: DocumentType
         var quizzes: [UserQuiz]
         var isLoading: Bool = false
-        
+
+        var categoryId: Int? = nil
+        var streamingText: String = ""
+        var isStreaming: Bool = false
+        var isQuizLoading: Bool = false
+        var typingFullText: String = ""
+        var typingIndex: Int = 0
+
         init(
             documentId: Int,
             summaryText: String,
             hasSolvedToday: Bool,
             isFirstTime: Bool,
             documentType: DocumentType,
-            quizzes: [UserQuiz]
+            quizzes: [UserQuiz],
+            categoryId: Int? = nil
         ) {
             self.documentId = documentId
             self.summaryText = summaryText
@@ -34,37 +42,220 @@ struct ContentSummaryFeature {
             self.isFirstTime = isFirstTime
             self.documentType = documentType
             self.quizzes = quizzes
+            self.categoryId = categoryId
+            // 카테고리 타입이면 onAppear 전에 미리 로딩 상태로 설정
+            self.isStreaming = documentType == .category && categoryId != nil
         }
     }
-    
+
     enum Action {
         case onAppear
         case startQuizButtonTapped
         case closeButtonTapped
         case delegate(Delegate)
+
+        case startStreaming
+        case streamEventReceived(CategoryStreamEvent)
+        case streamCompleted
+        case streamFailed(Error)
+        case fallbackResponse(Result<CategoryDocumentData, Error>)
+        case typingTick
+
+        // 스트리밍 완료 후 quizzes 로딩 (신규 문서 케이스)
+        case fetchDocumentMetaCompleted(Result<CategoryDocumentData, Error>)
+        case fetchQuizzesCompleted(Result<[UserQuiz], Error>)
     }
-    
+
     enum Delegate {
         case startQuiz(quizzes: [UserQuiz], isFirstTime: Bool)
         case cancelled
     }
-    
+
+    private enum CancelID { case streaming, typing }
+
+    @Dependency(\.apiClient) var apiClient
+
     var body: some ReducerOf<Self> {
         Reduce { state, action in
             switch action {
             case .onAppear:
+                if state.documentType == .category, state.categoryId != nil {
+                    return .send(.startStreaming)
+                }
                 return .none
-                
+
+            case .startStreaming:
+                guard let id = state.categoryId else { return .none }
+                state.isStreaming = true
+                state.streamingText = ""
+                return .run { send in
+                    do {
+                        for try await event in apiClient.streamCategoryDocument(categoryId: id) {
+                            await send(.streamEventReceived(event))
+                        }
+                    } catch {
+                        await send(.streamFailed(error))
+                    }
+                }.cancellable(id: CancelID.streaming, cancelInFlight: true)
+
+            case .streamEventReceived(let event):
+                switch event {
+                case .connected:
+                    return .none
+                case .textChunk(let s):
+                    state.streamingText += s
+                    return .none
+                case .titleChunk:
+                    return .none
+                case .completed:
+                    return .send(.streamCompleted)
+                }
+
+            case .streamCompleted:
+                guard !state.streamingText.isEmpty else {
+                    // 빈 스트림 — 서버가 이미 완성된 문서를 반환하지 않은 경우
+                    // GET fallback + 타이핑 애니메이션으로 처리
+                    guard let id = state.categoryId else {
+                        state.isStreaming = false
+                        return .none
+                    }
+                    return .run { send in
+                        let result = await Result {
+                            try await apiClient.fetchCategoryDocumentIfExists(categoryId: id)
+                        }
+                        await send(.fallbackResponse(result))
+                    }
+                }
+                // 정상 스트리밍 완료
+                state.summaryText = state.streamingText
+                state.streamingText = ""   // Markdown 렌더링으로 전환
+                state.isStreaming = false
+                // 퀴즈가 없으면(신규 문서) documentId GET 후 퀴즈 조회
+                guard state.quizzes.isEmpty, let categoryId = state.categoryId else {
+                    return .none
+                }
+                state.isQuizLoading = true
+                return .run { send in
+                    let result = await Result {
+                        try await apiClient.fetchCategoryDocumentIfExists(categoryId: categoryId)
+                    }
+                    await send(.fetchDocumentMetaCompleted(result))
+                }
+
+            case .streamFailed(let error):
+                print("[ContentSummary] streamFailed: \(error)")
+                // QUIZ-003: 이미 생성된 문서 → GET fallback + 타이핑 애니메이션
+                if let api = error as? APIError,
+                   case .serverError(let code, _, _) = api, code == "QUIZ-003" {
+                    guard let id = state.categoryId else { return .none }
+                    // isStreaming = true 유지 — fallback GET 동안 로딩 표시
+                    return .run { send in
+                        let result = await Result {
+                            try await apiClient.fetchCategoryDocumentIfExists(categoryId: id)
+                        }
+                        await send(.fallbackResponse(result))
+                    }
+                }
+                state.isStreaming = false
+                return .none
+
+            case .fallbackResponse(.success(let doc)):
+                // 서버에서 받은 실제 값으로 업데이트
+                state.documentId = doc.documentId
+                state.isFirstTime = doc.isFirstTime
+                state.hasSolvedToday = doc.hasSolvedToday
+                state.typingFullText = doc.content
+                state.typingIndex = 0
+                state.streamingText = ""
+                state.isStreaming = true
+                // quizzes가 없으면 타이핑 중에 병렬로 조회
+                let needsQuizzes = state.quizzes.isEmpty
+                let docId = doc.documentId
+                return .run { send in
+                    let chars = Array(doc.content)
+                    if needsQuizzes {
+                        // 퀴즈 조회를 타이핑과 병렬로 시작 (Task로 백그라운드 실행)
+                        let quizTask = Task {
+                            try await apiClient.fetchUserQuizzes(
+                                documentId: docId, documentType: .category
+                            )
+                        }
+                        for _ in chars {
+                            try await Task.sleep(for: .milliseconds(15))
+                            await send(.typingTick)
+                        }
+                        // 완료 틱: guard 통과 → isStreaming=false, summaryText 확정
+                        await send(.typingTick)
+                        let quizResult = await Result { try await quizTask.value }
+                        await send(.fetchQuizzesCompleted(quizResult))
+                    } else {
+                        for _ in chars {
+                            try await Task.sleep(for: .milliseconds(15))
+                            await send(.typingTick)
+                        }
+                        // 완료 틱: guard 통과 → isStreaming=false, summaryText 확정
+                        await send(.typingTick)
+                    }
+                }.cancellable(id: CancelID.typing, cancelInFlight: true)
+
+            case .fallbackResponse(.failure):
+                state.isStreaming = false
+                return .none
+
+            case .typingTick:
+                let chars = Array(state.typingFullText)
+                guard state.typingIndex < chars.count else {
+                    state.summaryText = state.typingFullText
+                    state.streamingText = ""   // Markdown 렌더링으로 전환
+                    state.isStreaming = false
+                    return .none
+                }
+                state.streamingText += String(chars[state.typingIndex])
+                state.typingIndex += 1
+                return .none
+
+            case .fetchDocumentMetaCompleted(.success(let doc)):
+                state.documentId = doc.documentId
+                state.isFirstTime = doc.isFirstTime
+                state.hasSolvedToday = doc.hasSolvedToday
+                // SSE로 이어붙인 텍스트 대신 서버에 저장된 원본으로 교체
+                state.summaryText = doc.content
+                return .run { [docId = doc.documentId] send in
+                    let result = await Result {
+                        try await apiClient.fetchUserQuizzes(documentId: docId, documentType: .category)
+                    }
+                    await send(.fetchQuizzesCompleted(result))
+                }
+
+            case .fetchDocumentMetaCompleted(.failure(let error)):
+                print("[ContentSummary] 문서 메타 조회 실패: \(error)")
+                state.isQuizLoading = false
+                return .none
+
+            case .fetchQuizzesCompleted(.success(let quizzes)):
+                state.quizzes = quizzes
+                state.isQuizLoading = false
+                print("[ContentSummary] 퀴즈 로딩 완료: \(quizzes.count)개")
+                return .none
+
+            case .fetchQuizzesCompleted(.failure(let error)):
+                print("[ContentSummary] 퀴즈 로딩 실패: \(error)")
+                state.isQuizLoading = false
+                return .none
+
             case .startQuizButtonTapped:
-                // quizzes와 isFirstTime 전달
                 return .send(.delegate(.startQuiz(
                     quizzes: state.quizzes,
                     isFirstTime: state.isFirstTime
                 )))
-                
+
             case .closeButtonTapped:
-                return .send(.delegate(.cancelled))
-                
+                return .merge(
+                    .cancel(id: CancelID.streaming),
+                    .cancel(id: CancelID.typing),
+                    .send(.delegate(.cancelled))
+                )
+
             case .delegate:
                 return .none
             }

--- a/TeumTeumEat/TeumTeumEat/Features/MainTab/MainTab/Quiz/ContentSummaryFeature.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/MainTab/MainTab/Quiz/ContentSummaryFeature.swift
@@ -21,6 +21,7 @@ struct ContentSummaryFeature {
         var isLoading: Bool = false
 
         var categoryId: Int? = nil
+        var goalId: Int? = nil
         var streamingText: String = ""
         var isStreaming: Bool = false
         var isQuizLoading: Bool = false
@@ -34,7 +35,8 @@ struct ContentSummaryFeature {
             isFirstTime: Bool,
             documentType: DocumentType,
             quizzes: [UserQuiz],
-            categoryId: Int? = nil
+            categoryId: Int? = nil,
+            goalId: Int? = nil
         ) {
             self.documentId = documentId
             self.summaryText = summaryText
@@ -43,8 +45,10 @@ struct ContentSummaryFeature {
             self.documentType = documentType
             self.quizzes = quizzes
             self.categoryId = categoryId
-            // 카테고리 타입이면 onAppear 전에 미리 로딩 상태로 설정
-            self.isStreaming = documentType == .category && categoryId != nil
+            self.goalId = goalId
+            // 스트리밍 타입이면 onAppear 전에 미리 로딩 상태로 설정
+            self.isStreaming = (documentType == .category && categoryId != nil)
+                            || (documentType == .document && goalId != nil)
         }
     }
 
@@ -59,9 +63,10 @@ struct ContentSummaryFeature {
         case streamCompleted
         case streamFailed(Error)
         case fallbackResponse(Result<CategoryDocumentData, Error>)
+        case pdfFallbackResponse(Result<PDFSummaryData, Error>)
         case typingTick
 
-        // 스트리밍 완료 후 quizzes 로딩 (신규 문서 케이스)
+        // 스트리밍 완료 후 quizzes 로딩 (신규 문서 케이스 - 카테고리)
         case fetchDocumentMetaCompleted(Result<CategoryDocumentData, Error>)
         case fetchQuizzesCompleted(Result<[UserQuiz], Error>)
     }
@@ -82,21 +87,39 @@ struct ContentSummaryFeature {
                 if state.documentType == .category, state.categoryId != nil {
                     return .send(.startStreaming)
                 }
+                if state.documentType == .document, state.goalId != nil {
+                    return .send(.startStreaming)
+                }
                 return .none
 
             case .startStreaming:
-                guard let id = state.categoryId else { return .none }
                 state.isStreaming = true
                 state.streamingText = ""
-                return .run { send in
-                    do {
-                        for try await event in apiClient.streamCategoryDocument(categoryId: id) {
-                            await send(.streamEventReceived(event))
+                if state.documentType == .category {
+                    guard let id = state.categoryId else { return .none }
+                    return .run { send in
+                        do {
+                            for try await event in apiClient.streamCategoryDocument(categoryId: id) {
+                                await send(.streamEventReceived(event))
+                            }
+                        } catch {
+                            await send(.streamFailed(error))
                         }
-                    } catch {
-                        await send(.streamFailed(error))
-                    }
-                }.cancellable(id: CancelID.streaming, cancelInFlight: true)
+                    }.cancellable(id: CancelID.streaming, cancelInFlight: true)
+                } else if state.documentType == .document {
+                    guard let goalId = state.goalId else { return .none }
+                    let docId = state.documentId
+                    return .run { send in
+                        do {
+                            for try await event in apiClient.streamPDFSummary(goalId: goalId, documentId: docId) {
+                                await send(.streamEventReceived(event))
+                            }
+                        } catch {
+                            await send(.streamFailed(error))
+                        }
+                    }.cancellable(id: CancelID.streaming, cancelInFlight: true)
+                }
+                return .none
 
             case .streamEventReceived(let event):
                 switch event {
@@ -113,54 +136,93 @@ struct ContentSummaryFeature {
 
             case .streamCompleted:
                 guard !state.streamingText.isEmpty else {
-                    // 빈 스트림 — 서버가 이미 완성된 문서를 반환하지 않은 경우
-                    // GET fallback + 타이핑 애니메이션으로 처리
-                    guard let id = state.categoryId else {
-                        state.isStreaming = false
-                        return .none
-                    }
-                    return .run { send in
-                        let result = await Result {
-                            try await apiClient.fetchCategoryDocumentIfExists(categoryId: id)
+                    // 빈 스트림 → GET fallback + 타이핑 애니메이션
+                    if state.documentType == .category {
+                        guard let id = state.categoryId else {
+                            state.isStreaming = false; return .none
                         }
-                        await send(.fallbackResponse(result))
+                        return .run { send in
+                            let result = await Result {
+                                try await apiClient.fetchCategoryDocumentIfExists(categoryId: id)
+                            }
+                            await send(.fallbackResponse(result))
+                        }
+                    } else if state.documentType == .document {
+                        guard let goalId = state.goalId else {
+                            state.isStreaming = false; return .none
+                        }
+                        let docId = state.documentId
+                        return .run { send in
+                            let result = await Result {
+                                try await apiClient.fetchPDFSummaryOnly(goalId: goalId, documentId: docId)
+                            }
+                            await send(.pdfFallbackResponse(result))
+                        }
                     }
+                    state.isStreaming = false
+                    return .none
                 }
                 // 정상 스트리밍 완료
                 state.summaryText = state.streamingText
                 state.streamingText = ""   // Markdown 렌더링으로 전환
                 state.isStreaming = false
-                // 퀴즈가 없으면(신규 문서) documentId GET 후 퀴즈 조회
-                guard state.quizzes.isEmpty, let categoryId = state.categoryId else {
-                    return .none
-                }
-                state.isQuizLoading = true
-                return .run { send in
-                    let result = await Result {
-                        try await apiClient.fetchCategoryDocumentIfExists(categoryId: categoryId)
+
+                if state.documentType == .category {
+                    // 퀴즈가 없으면(신규 문서) documentId GET 후 퀴즈 조회
+                    guard state.quizzes.isEmpty, let categoryId = state.categoryId else {
+                        return .none
                     }
-                    await send(.fetchDocumentMetaCompleted(result))
+                    state.isQuizLoading = true
+                    return .run { send in
+                        let result = await Result {
+                            try await apiClient.fetchCategoryDocumentIfExists(categoryId: categoryId)
+                        }
+                        await send(.fetchDocumentMetaCompleted(result))
+                    }
+                } else if state.documentType == .document {
+                    // PDF: documentId 이미 알고있으므로 바로 퀴즈 조회
+                    guard state.quizzes.isEmpty else { return .none }
+                    state.isQuizLoading = true
+                    let docId = state.documentId
+                    return .run { send in
+                        let result = await Result {
+                            try await apiClient.fetchUserQuizzes(documentId: docId, documentType: .document)
+                        }
+                        await send(.fetchQuizzesCompleted(result))
+                    }
                 }
+                return .none
 
             case .streamFailed(let error):
                 print("[ContentSummary] streamFailed: \(error)")
                 // QUIZ-003: 이미 생성된 문서 → GET fallback + 타이핑 애니메이션
                 if let api = error as? APIError,
                    case .serverError(let code, _, _) = api, code == "QUIZ-003" {
-                    guard let id = state.categoryId else { return .none }
-                    // isStreaming = true 유지 — fallback GET 동안 로딩 표시
-                    return .run { send in
-                        let result = await Result {
-                            try await apiClient.fetchCategoryDocumentIfExists(categoryId: id)
+                    if state.documentType == .category {
+                        guard let id = state.categoryId else { return .none }
+                        // isStreaming = true 유지 — fallback GET 동안 로딩 표시
+                        return .run { send in
+                            let result = await Result {
+                                try await apiClient.fetchCategoryDocumentIfExists(categoryId: id)
+                            }
+                            await send(.fallbackResponse(result))
                         }
-                        await send(.fallbackResponse(result))
+                    } else if state.documentType == .document {
+                        guard let goalId = state.goalId else { return .none }
+                        let docId = state.documentId
+                        return .run { send in
+                            let result = await Result {
+                                try await apiClient.fetchPDFSummaryOnly(goalId: goalId, documentId: docId)
+                            }
+                            await send(.pdfFallbackResponse(result))
+                        }
                     }
                 }
                 state.isStreaming = false
                 return .none
 
             case .fallbackResponse(.success(let doc)):
-                // 서버에서 받은 실제 값으로 업데이트
+                // 카테고리 fallback: 서버에서 받은 실제 값으로 업데이트
                 state.documentId = doc.documentId
                 state.isFirstTime = doc.isFirstTime
                 state.hasSolvedToday = doc.hasSolvedToday
@@ -169,22 +231,20 @@ struct ContentSummaryFeature {
                 state.streamingText = ""
                 state.isStreaming = true
                 // quizzes가 없으면 타이핑 중에 병렬로 조회
-                let needsQuizzes = state.quizzes.isEmpty
-                let docId = doc.documentId
+                let needsQuizzesC = state.quizzes.isEmpty
+                let docIdC = doc.documentId
                 return .run { send in
                     let chars = Array(doc.content)
-                    if needsQuizzes {
-                        // 퀴즈 조회를 타이핑과 병렬로 시작 (Task로 백그라운드 실행)
+                    if needsQuizzesC {
                         let quizTask = Task {
                             try await apiClient.fetchUserQuizzes(
-                                documentId: docId, documentType: .category
+                                documentId: docIdC, documentType: .category
                             )
                         }
                         for _ in chars {
                             try await Task.sleep(for: .milliseconds(15))
                             await send(.typingTick)
                         }
-                        // 완료 틱: guard 통과 → isStreaming=false, summaryText 확정
                         await send(.typingTick)
                         let quizResult = await Result { try await quizTask.value }
                         await send(.fetchQuizzesCompleted(quizResult))
@@ -193,12 +253,50 @@ struct ContentSummaryFeature {
                             try await Task.sleep(for: .milliseconds(15))
                             await send(.typingTick)
                         }
-                        // 완료 틱: guard 통과 → isStreaming=false, summaryText 확정
                         await send(.typingTick)
                     }
                 }.cancellable(id: CancelID.typing, cancelInFlight: true)
 
             case .fallbackResponse(.failure):
+                state.isStreaming = false
+                return .none
+
+            case .pdfFallbackResponse(.success(let summary)):
+                // PDF fallback: 서버에서 받은 실제 값으로 업데이트
+                state.documentId = summary.documentId
+                state.isFirstTime = summary.isFirstTime
+                state.hasSolvedToday = summary.hasSolvedToday
+                state.typingFullText = summary.summary
+                state.typingIndex = 0
+                state.streamingText = ""
+                state.isStreaming = true
+                let needsQuizzesP = state.quizzes.isEmpty
+                let docIdP = summary.documentId
+                return .run { send in
+                    let chars = Array(summary.summary)
+                    if needsQuizzesP {
+                        let quizTask = Task {
+                            try await apiClient.fetchUserQuizzes(
+                                documentId: docIdP, documentType: .document
+                            )
+                        }
+                        for _ in chars {
+                            try await Task.sleep(for: .milliseconds(15))
+                            await send(.typingTick)
+                        }
+                        await send(.typingTick)
+                        let quizResult = await Result { try await quizTask.value }
+                        await send(.fetchQuizzesCompleted(quizResult))
+                    } else {
+                        for _ in chars {
+                            try await Task.sleep(for: .milliseconds(15))
+                            await send(.typingTick)
+                        }
+                        await send(.typingTick)
+                    }
+                }.cancellable(id: CancelID.typing, cancelInFlight: true)
+
+            case .pdfFallbackResponse(.failure):
                 state.isStreaming = false
                 return .none
 

--- a/TeumTeumEat/TeumTeumEat/Features/MainTab/MainTab/Quiz/ContentSummaryFeature.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/MainTab/MainTab/Quiz/ContentSummaryFeature.swift
@@ -27,6 +27,7 @@ struct ContentSummaryFeature {
         var isQuizLoading: Bool = false
         var typingFullText: String = ""
         var typingIndex: Int = 0
+        var errorMessage: String? = nil
 
         init(
             documentId: Int,
@@ -56,6 +57,7 @@ struct ContentSummaryFeature {
         case onAppear
         case startQuizButtonTapped
         case closeButtonTapped
+        case errorAlertDismissed
         case delegate(Delegate)
 
         case startStreaming
@@ -196,6 +198,13 @@ struct ContentSummaryFeature {
 
             case .streamFailed(let error):
                 print("[ContentSummary] streamFailed: \(error)")
+                // QUIZ-002: 퀴즈 횟수 소진
+                if let api = error as? APIError,
+                   case .serverError(let code, let message, _) = api, code == "QUIZ-002" {
+                    state.isStreaming = false
+                    state.errorMessage = message.isEmpty ? "오늘의 퀴즈 횟수를 모두 소진했어요." : message
+                    return .none
+                }
                 // QUIZ-003: 이미 생성된 문서 → GET fallback + 타이핑 애니메이션
                 if let api = error as? APIError,
                    case .serverError(let code, _, _) = api, code == "QUIZ-003" {
@@ -319,8 +328,7 @@ struct ContentSummaryFeature {
                 state.documentId = doc.documentId
                 state.isFirstTime = doc.isFirstTime
                 state.hasSolvedToday = doc.hasSolvedToday
-                // SSE로 이어붙인 텍스트 대신 서버에 저장된 원본으로 교체
-                state.summaryText = doc.content
+                // summaryText는 SSE로 이미 완성된 상태 — 서버 저장본으로 덮어쓰지 않음
                 return .run { [docId = doc.documentId] send in
                     let result = await Result {
                         try await apiClient.fetchUserQuizzes(documentId: docId, documentType: .category)
@@ -343,6 +351,10 @@ struct ContentSummaryFeature {
                 print("[ContentSummary] 퀴즈 로딩 실패: \(error)")
                 state.isQuizLoading = false
                 return .none
+
+            case .errorAlertDismissed:
+                state.errorMessage = nil
+                return .send(.delegate(.cancelled))
 
             case .startQuizButtonTapped:
                 return .send(.delegate(.startQuiz(

--- a/TeumTeumEat/TeumTeumEat/Features/MainTab/MainTab/Quiz/ContentSummaryView.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/MainTab/MainTab/Quiz/ContentSummaryView.swift
@@ -130,6 +130,17 @@ struct ContentSummaryView: View {
         .onAppear {
             store.send(.onAppear)
         }
+        .alert(
+            "퀴즈를 시작할 수 없어요",
+            isPresented: Binding(
+                get: { store.errorMessage != nil },
+                set: { _ in store.send(.errorAlertDismissed) }
+            )
+        ) {
+            Button("확인") { store.send(.errorAlertDismissed) }
+        } message: {
+            Text(store.errorMessage ?? "")
+        }
     }
 }
 

--- a/TeumTeumEat/TeumTeumEat/Features/MainTab/MainTab/Quiz/ContentSummaryView.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/MainTab/MainTab/Quiz/ContentSummaryView.swift
@@ -104,20 +104,37 @@ struct ContentSummaryView: View {
                     
                     // 버튼 영역
                     VStack(spacing: 0) {
-                        Button(action: {
-                            store.send(.startQuizButtonTapped)
-                        }) {
-                            Text("퀴즈 풀기")
-                                .font(.system(size: 18, weight: .semibold))
-                                .foregroundColor(.white)
-                                .frame(maxWidth: .infinity)
-                                .frame(height: 56)
-                                .background(Color.blue500)
-                                .cornerRadius(12)
+                        if !store.isStreaming && store.isQuizLoading {
+                            // SSE 완료 후 퀴즈 로딩 중
+                            HStack(spacing: 10) {
+                                ProgressView()
+                                    .progressViewStyle(CircularProgressViewStyle(tint: .white))
+                                    .scaleEffect(0.9)
+                                Text("문제 불러오는 중")
+                                    .font(.system(size: 18, weight: .semibold))
+                                    .foregroundColor(.white)
+                            }
+                            .frame(maxWidth: .infinity)
+                            .frame(height: 56)
+                            .background(Color.blue500.opacity(0.6))
+                            .cornerRadius(12)
+                            .padding(.horizontal, 20)
+                        } else {
+                            Button(action: {
+                                store.send(.startQuizButtonTapped)
+                            }) {
+                                Text("퀴즈 풀기")
+                                    .font(.system(size: 18, weight: .semibold))
+                                    .foregroundColor(.white)
+                                    .frame(maxWidth: .infinity)
+                                    .frame(height: 56)
+                                    .background(Color.blue500)
+                                    .cornerRadius(12)
+                            }
+                            .disabled(store.isStreaming)
+                            .opacity(store.isStreaming ? 0.5 : 1.0)
+                            .padding(.horizontal, 20)
                         }
-                        .disabled(store.isStreaming || store.isQuizLoading)
-                        .opacity(store.isStreaming || store.isQuizLoading ? 0.5 : 1.0)
-                        .padding(.horizontal, 20)
                     }
                     .padding(.bottom, 34)
                     .background(Color.white)

--- a/TeumTeumEat/TeumTeumEat/Features/MainTab/MainTab/Quiz/ContentSummaryView.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/MainTab/MainTab/Quiz/ContentSummaryView.swift
@@ -47,17 +47,44 @@ struct ContentSummaryView: View {
                     .background(Color.white)
                     
                     // Markdown 콘텐츠
-                    ScrollView {
-                        Markdown(store.summaryText)
-//                            .markdownTheme(.custom)
-                            .markdownTheme(.gitHub)
-                            .colorScheme(.light)
-                            .padding(.horizontal, 20)
-                            .padding(.top, 24)
-                            .padding(.bottom, 180)
+                    ScrollViewReader { proxy in
+                        ScrollView {
+                            if store.isStreaming && store.streamingText.isEmpty {
+                                // 연결/로딩 중
+                                VStack {
+                                    ProgressView()
+                                        .scaleEffect(1.2)
+                                }
+                                .frame(maxWidth: .infinity)
+                                .padding(.top, 80)
+                            } else if store.isStreaming {
+                                // 스트리밍 텍스트 수신 중 — Markdown 실시간 렌더링
+                                Markdown(store.streamingText)
+                                    .markdownTheme(.gitHub)
+                                    .colorScheme(.light)
+                                    .padding(.horizontal, 20)
+                                    .padding(.top, 24)
+                                    .padding(.bottom, 180)
+                            } else {
+                                // 완료 — Markdown 렌더링
+                                Markdown(store.summaryText)
+                                    .markdownTheme(.gitHub)
+                                    .colorScheme(.light)
+                                    .padding(.horizontal, 20)
+                                    .padding(.top, 24)
+                                    .padding(.bottom, 180)
+                            }
+
+                            Color.clear
+                                .frame(height: 1)
+                                .id("streamingBottom")
+                        }
+                        .onChange(of: store.streamingText) { _ in
+                            proxy.scrollTo("streamingBottom", anchor: .bottom)
+                        }
+                        .scrollDismissesKeyboard(.interactively)
+                        .background(Color.white)
                     }
-                    .scrollDismissesKeyboard(.interactively)
-                    .background(Color.white)
                 }
                 .background(Color.white)
                 
@@ -88,6 +115,8 @@ struct ContentSummaryView: View {
                                 .background(Color.blue500)
                                 .cornerRadius(12)
                         }
+                        .disabled(store.isStreaming || store.isQuizLoading)
+                        .opacity(store.isStreaming || store.isQuizLoading ? 0.5 : 1.0)
                         .padding(.horizontal, 20)
                     }
                     .padding(.bottom, 34)
@@ -103,6 +132,7 @@ struct ContentSummaryView: View {
         }
     }
 }
+
 
 extension Theme {
     static let custom = Theme()

--- a/TeumTeumEat/TeumTeumEat/Features/MainTab/MainTab/Quiz/QuizFlowFeature.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/MainTab/MainTab/Quiz/QuizFlowFeature.swift
@@ -78,6 +78,7 @@ struct QuizFlowFeature {
         Reduce { state, action in
             switch action {
             case .contentSummary(.delegate(.startQuiz(let quizzes, let isFirstTime))):
+                state.quizzes = quizzes  // ContentSummary에서 로드한 실제 퀴즈 목록 저장
                 if isFirstTime {
                     state.currentStep = .quizGuide
                     state.quizGuide = QuizGuideFeature.State()

--- a/TeumTeumEat/TeumTeumEat/Features/MainTab/MainTab/Quiz/QuizFlowFeature.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/MainTab/MainTab/Quiz/QuizFlowFeature.swift
@@ -104,6 +104,10 @@ struct QuizFlowFeature {
                 return .send(.delegate(.cancelled))
 
             case .quizGuide(.delegate(.startQuiz)):
+                guard !state.quizzes.isEmpty else {
+                    print("[QuizFlow] 퀴즈가 없어 시작 불가 - completeQuizSet 호출 건너뜀")
+                    return .none
+                }
                 state.currentStep = .quiz
                 let convertedQuizzes = state.quizzes.map { Quiz(from: $0) }
                 state.quiz = QuizFeature.State(quizzes: convertedQuizzes)

--- a/TeumTeumEat/TeumTeumEat/Features/Onboarding/Models/fileUpload.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/Onboarding/Models/fileUpload.swift
@@ -76,3 +76,10 @@ enum SSEFailureReason: String, Equatable {
         }
     }
 }
+
+enum CategoryStreamEvent: Equatable {
+    case connected
+    case textChunk(String)   // event:message data
+    case titleChunk(String)  // event:title data
+    case completed           // 스트림 EOF
+}

--- a/TeumTeumEat/TeumTeumEat/Features/Onboarding/Screens/Loading/OnboardingLoadingFeature.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/Onboarding/Screens/Loading/OnboardingLoadingFeature.swift
@@ -282,14 +282,21 @@ struct OnboardingLoadingFeature {
 
                 case .processing(let remainMs):
                     print("[SSE] 처리 중 - 남은 시간: \(remainMs)ms")
+
+                    // remain: 0 → 서버가 잔여 시간을 모르는 경우, indeterminate 처리
+                    guard remainMs > 0 else {
+                        if state.sseProgress < 0.85 {
+                            state.sseProgress = min(state.sseProgress + 0.05, 0.85)
+                        }
+                        return .none
+                    }
+
                     if state.totalInitialMs == nil {
                         state.totalInitialMs = remainMs
                     }
                     let total = state.totalInitialMs ?? remainMs
                     state.remainingSeconds = max(0, remainMs / 1000)
-                    state.sseProgress = total > 0
-                        ? max(0.05, Double(total - remainMs) / Double(total))
-                        : 0.1
+                    state.sseProgress = max(0.05, Double(total - remainMs) / Double(total))
 
                     let secondsToCount = remainMs / 1000
                     return .run { send in


### PR DESCRIPTION
## 🎫 What is the PR?
카테고리 및 PDF 요약글을 SSE(Server-Sent Events)로 실시간 스트리밍하여 사용자에게 보여주는 기능을 구현했습니다.
기존에는 홈에서 요약글을 미리 조회 후 한 번에 표시했지만, 이제 요약 화면 진입 시 SSE로 받아와 Markdown 실시간 렌더링합니다.

## 🎫 Changes
- **카테고리 SSE 스트리밍**: `POST .../categories/{id}/documents/daily/stream` 엔드포인트로 실시간 스트리밍
- **PDF SSE 스트리밍**: `POST .../goals/{goalId}/documents/{documentId}/summary/stream` 엔드포인트로 실시간 스트리밍
- **QUIZ-003 fallback**: 이미 생성된 문서는 GET으로 조회 후 타이핑 애니메이션으로 표시
- **Markdown 실시간 렌더링**: 스트리밍 중에도 Markdown 포맷 적용 (MarkdownUI)
- **자동 스크롤**: 스트리밍 텍스트 추가 시 하단으로 자동 스크롤
- **퀴즈 병렬 fetch**: 타이핑 애니메이션 중 퀴즈를 백그라운드에서 병렬 조회
- **홈 구조 통일**: 카테고리/PDF 모두 홈에서 상태 조회만, 요약 화면 진입 시 SSE 처리
- **스낵 이미지**: `goal.documentId(categoryId)` + 오늘 날짜 기반 안정적 랜덤 이미지
- **퀴즈 결과 totalQuizCount 오류 수정**

## 🎫 Thoughts
SSE 파싱 시 서버가 빈 줄 구분자 없이 `event:/data:` 를 연속 전송하는 구조여서, 새 `event:` 라인 도착 시 이전 이벤트를 flush하는 방식으로 처리했습니다.
또한 서버가 HTTP 200 바디 안에 `{"code":"QUIZ-003"}` JSON을 raw 텍스트로 삽입하는 방식으로 에러를 반환해, 스트림 EOF 후 rawBuffer를 JSON 파싱하여 감지합니다.
빈 `data:` 이벤트(`event:message` + `data:`)는 줄바꿈(`\n`)을 의미하며, 이를 처리하지 않으면 Markdown 헤딩 아래 본문이 이어붙어 전부 헤딩 크기로 렌더링되는 문제가 있었습니다.

## 🎫 Screenshot
| 구현 내용 | 13 mini |
| :-------------: | :----------: |
| GIF | <img src = "https://github.com/user-attachments/assets/eb21ec34-657d-48c3-8c7a-019f22d00b67" width ="250"> |

## 🎫 To Reviewers
- `ContentSummaryFeature`의 `streamFailed` → QUIZ-003 감지 → fallback GET → 타이핑 애니메이션 흐름을 중점적으로 봐주세요.
- SSE rawBuffer JSON 에러 감지 로직(`APIClient.swift` - `streamCategoryDocument`, `streamPDFSummary`)

## 🖥️ 주요 코드 설명

`APIClient`
- `streamCategoryDocument(categoryId:)` / `streamPDFSummary(goalId:documentId:)`: POST SSE 스트림, `event:` 라인 도착 시 이전 이벤트 flush
- `parseCategorySSEEvent`: 빈 `data:` → `\n` 변환

```swift
case "message": return .textChunk(data.isEmpty ? "\n" : data)
```

`ContentSummaryFeature`
- `onAppear` → `startStreaming` → `streamEventReceived` → `streamCompleted`
- QUIZ-003 시 `fallbackResponse` / `pdfFallbackResponse` → 타이핑 애니메이션

```swift
// 새 event: 라인 도착 시 이전 이벤트 즉시 flush (서버가 빈줄 미전송)
} else if line.hasPrefix("event:") {
    if !eventType.isEmpty {
        if let event = parseCategorySSEEvent(type: eventType, data: eventData) {
            continuation.yield(event)
        }
    }
    eventType = String(line.dropFirst(6)).trimmingCharacters(in: .whitespaces)
    eventData = ""
}
```

`HomeFeature`
- 카테고리/PDF 모두 홈에서 상태 조회만, `currentSnackImage`는 goal 데이터 + 오늘 날짜로 안정적 랜덤 이미지

```swift
if goal.type == "DOCUMENT" {
    let id = goal.documentId ?? goal.goalId
    return SnackImageMapper.snackImage(for: id, createdAt: today)
}
```

## ✅ Check List
- [ ] Merge 대상 브랜치가 올바른가?
- [ ] 최종 코드가 에러 없이 잘 동작하는가?
- [ ] 전체 변경사항이 500줄을 넘지 않는가?

## 🎫 Related Issues
- Resolved: #46