### PR TITLE
[fix] #50 fallback 애니메이션 제거 및 dev/prod 환경 분기 처리

### DIFF
--- a/TeumTeumEat/TeumTeumEat/Features/Login/AppConfig.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/Login/AppConfig.swift
@@ -29,10 +29,17 @@ enum Config  {
     }
     
     static var baseURL: String {
+        #if DEBUG
+        guard let url = Bundle.main.object(forInfoDictionaryKey: "DEV_BASE_URL") as? String else {
+            fatalError("DEV_BASE_URL not found")
+        }
+        return url
+        #else
         guard let url = Bundle.main.object(forInfoDictionaryKey: "BASE_URL") as? String else {
             fatalError("API_BASE_URL not found")
         }
         return url
+        #endif
     }
 
     static var admobAppID: String {

--- a/TeumTeumEat/TeumTeumEat/Features/MainTab/MainTab/Quiz/ContentSummaryFeature.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/MainTab/MainTab/Quiz/ContentSummaryFeature.swift
@@ -25,8 +25,6 @@ struct ContentSummaryFeature {
         var streamingText: String = ""
         var isStreaming: Bool = false
         var isQuizLoading: Bool = false
-        var typingFullText: String = ""
-        var typingIndex: Int = 0
         var errorMessage: String? = nil
 
         init(
@@ -66,7 +64,6 @@ struct ContentSummaryFeature {
         case streamFailed(Error)
         case fallbackResponse(Result<CategoryDocumentData, Error>)
         case pdfFallbackResponse(Result<PDFSummaryData, Error>)
-        case typingTick
 
         // 스트리밍 완료 후 quizzes 로딩 (신규 문서 케이스 - 카테고리)
         case fetchDocumentMetaCompleted(Result<CategoryDocumentData, Error>)
@@ -78,7 +75,7 @@ struct ContentSummaryFeature {
         case cancelled
     }
 
-    private enum CancelID { case streaming, typing }
+    private enum CancelID { case streaming }
 
     @Dependency(\.apiClient) var apiClient
 
@@ -236,37 +233,19 @@ struct ContentSummaryFeature {
                 state.documentId = doc.documentId
                 state.isFirstTime = doc.isFirstTime
                 state.hasSolvedToday = doc.hasSolvedToday
-                state.typingFullText = doc.content
-                state.typingIndex = 0
+                state.summaryText = doc.content
                 state.streamingText = ""
-                state.isStreaming = true
-                // quizzes가 없으면 타이핑 중에 병렬로 조회
+                state.isStreaming = false
                 let needsQuizzesC = state.quizzes.isEmpty
                 if needsQuizzesC { state.isQuizLoading = true }
                 let docIdC = doc.documentId
+                guard needsQuizzesC else { return .none }
                 return .run { send in
-                    let chars = Array(doc.content)
-                    if needsQuizzesC {
-                        let quizTask = Task {
-                            try await apiClient.fetchUserQuizzes(
-                                documentId: docIdC, documentType: .category
-                            )
-                        }
-                        for _ in chars {
-                            try await Task.sleep(for: .milliseconds(15))
-                            await send(.typingTick)
-                        }
-                        await send(.typingTick)
-                        let quizResult = await Result { try await quizTask.value }
-                        await send(.fetchQuizzesCompleted(quizResult))
-                    } else {
-                        for _ in chars {
-                            try await Task.sleep(for: .milliseconds(15))
-                            await send(.typingTick)
-                        }
-                        await send(.typingTick)
+                    let quizResult = await Result {
+                        try await apiClient.fetchUserQuizzes(documentId: docIdC, documentType: .category)
                     }
-                }.cancellable(id: CancelID.typing, cancelInFlight: true)
+                    await send(.fetchQuizzesCompleted(quizResult))
+                }
 
             case .fallbackResponse(.failure):
                 state.isStreaming = false
@@ -277,51 +256,22 @@ struct ContentSummaryFeature {
                 state.documentId = summary.documentId
                 state.isFirstTime = summary.isFirstTime
                 state.hasSolvedToday = summary.hasSolvedToday
-                state.typingFullText = summary.summary
-                state.typingIndex = 0
+                state.summaryText = summary.summary
                 state.streamingText = ""
-                state.isStreaming = true
+                state.isStreaming = false
                 let needsQuizzesP = state.quizzes.isEmpty
                 if needsQuizzesP { state.isQuizLoading = true }
                 let docIdP = summary.documentId
+                guard needsQuizzesP else { return .none }
                 return .run { send in
-                    let chars = Array(summary.summary)
-                    if needsQuizzesP {
-                        let quizTask = Task {
-                            try await apiClient.fetchUserQuizzes(
-                                documentId: docIdP, documentType: .document
-                            )
-                        }
-                        for _ in chars {
-                            try await Task.sleep(for: .milliseconds(15))
-                            await send(.typingTick)
-                        }
-                        await send(.typingTick)
-                        let quizResult = await Result { try await quizTask.value }
-                        await send(.fetchQuizzesCompleted(quizResult))
-                    } else {
-                        for _ in chars {
-                            try await Task.sleep(for: .milliseconds(15))
-                            await send(.typingTick)
-                        }
-                        await send(.typingTick)
+                    let quizResult = await Result {
+                        try await apiClient.fetchUserQuizzes(documentId: docIdP, documentType: .document)
                     }
-                }.cancellable(id: CancelID.typing, cancelInFlight: true)
+                    await send(.fetchQuizzesCompleted(quizResult))
+                }
 
             case .pdfFallbackResponse(.failure):
                 state.isStreaming = false
-                return .none
-
-            case .typingTick:
-                let chars = Array(state.typingFullText)
-                guard state.typingIndex < chars.count else {
-                    state.summaryText = state.typingFullText
-                    state.streamingText = ""   // Markdown 렌더링으로 전환
-                    state.isStreaming = false
-                    return .none
-                }
-                state.streamingText += String(chars[state.typingIndex])
-                state.typingIndex += 1
                 return .none
 
             case .fetchDocumentMetaCompleted(.success(let doc)):
@@ -365,7 +315,6 @@ struct ContentSummaryFeature {
             case .closeButtonTapped:
                 return .merge(
                     .cancel(id: CancelID.streaming),
-                    .cancel(id: CancelID.typing),
                     .send(.delegate(.cancelled))
                 )
 

--- a/TeumTeumEat/TeumTeumEat/Info.plist
+++ b/TeumTeumEat/TeumTeumEat/Info.plist
@@ -6,6 +6,8 @@
 	<false/>
 	<key>BASE_URL</key>
 	<string>$(BASE_URL)</string>
+	<key>DEV_BASE_URL</key>
+	<string>$(DEV_BASE_URL)</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>


### PR DESCRIPTION
## 🎫 What is the PR?
fallback 콘텐츠 타이핑 애니메이션 제거 및 dev/prod 서버 환경 분기 처리 추가

## 🎫 Changes
- SSE 실패 또는 QUIZ-003 응답 시 daily API fallback 콘텐츠를 한 글자씩 보여주던 타이핑 애니메이션 제거, 즉시 표시로 변경
- Debug 빌드는 dev 서버(`api-dev.teumteumeat.co.kr`), Release 빌드는 prod 서버(`api.teumteumeat.co.kr`)로 자동 분기 처리

## 🎫 Thoughts
타이핑 애니메이션은 SSE 스트리밍처럼 보이게 하려는 의도였지만, 실제로는 이미 완성된 텍스트를 인위적으로 지연시키는 것이라 UX상 불필요하다고 판단해 제거했습니다.
환경 분기는 `#if DEBUG` 컴파일 플래그를 활용해 Run → dev, Archive → prod로 자동 전환되도록 했습니다.



## 🎫 Screenshot
|  처음 stream 요청시  |  이미 요약이 만들어졌을 때  |
| :----------: | :----------: |
| <img src = "" width ="250"> | <img src = "https://github.com/user-attachments/assets/7eb3cdde-f40d-46e9-a687-bc286966debf" width ="250"> |

## 🎫 To Reviewers
- `Config.xcconfig`는 gitignore 대상이라 커밋에 포함되지 않았습니다. `DEV_BASE_URL = https://api-dev.teumteumeat.co.kr` 항목을 로컬 xcconfig에 직접 추가해주세요.

## 🖥️ 주요 코드 설명

`AppConfig.swift`
- `#if DEBUG` 분기로 dev/prod URL 자동 선택

```swift
static var baseURL: String {
    #if DEBUG
    guard let url = Bundle.main.object(forInfoDictionaryKey: "DEV_BASE_URL") as? String else {
        fatalError("DEV_BASE_URL not found")
    }
    return url
    #else
    guard let url = Bundle.main.object(forInfoDictionaryKey: "BASE_URL") as? String else {
        fatalError("API_BASE_URL not found")
    }
    return url
    #endif
}
```

`ContentSummaryFeature.swift`
- fallback 응답 시 타이핑 루프 제거, `summaryText`에 즉시 할당

```swift
case .fallbackResponse(.success(let doc)):
    state.summaryText = doc.content
    state.streamingText = ""
    state.isStreaming = false
```

## ✅ Check List
- [ ] Merge 대상 브랜치가 올바른가?
- [ ] 최종 코드가 에러 없이 잘 동작하는가?
- [ ] 전체 변경사항이 500줄을 넘지 않는가?

## 🎫 Related Issues
- Resolved: #50