### PR TITLE
Refactor/#52

### DIFF
--- a/.github/workflows/demo-app-testflight.yml
+++ b/.github/workflows/demo-app-testflight.yml
@@ -23,15 +23,14 @@ jobs:
           ruby-version: '3.3'
           bundler-cache: true
 
-      - name: Install mise
-        run: |
-          curl https://mise.run | sh
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
-
       - name: Install tuist via mise
-        run: |
-          ~/.local/bin/mise use --global tuist@4.9.0
-          echo "$HOME/.local/share/mise/shims" >> $GITHUB_PATH
+        uses: jdx/mise-action@v2
+        with:
+          mise_toml: |
+            [tools]
+            tuist = "4.9.0"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Deploy to TestFlight
         env:

--- a/.github/workflows/demo-app-testflight.yml
+++ b/.github/workflows/demo-app-testflight.yml
@@ -41,3 +41,10 @@ jobs:
           ASC_API_KEY_CONTENT:       ${{ secrets.ASC_API_KEY_CONTENT }}
           TEAM_ID:                   ${{ secrets.TEAM_ID }}
         run: bundle exec fastlane release_demo_app
+
+      - name: Upload gym log (on failure)
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: gym-log
+          path: ~/Library/Logs/gym/

--- a/.github/workflows/demo-app-testflight.yml
+++ b/.github/workflows/demo-app-testflight.yml
@@ -29,8 +29,7 @@ jobs:
           mise_toml: |
             [tools]
             tuist = "4.9.0"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Deploy to TestFlight
         env:

--- a/.github/workflows/demo-app-testflight.yml
+++ b/.github/workflows/demo-app-testflight.yml
@@ -31,6 +31,9 @@ jobs:
             tuist = "4.9.0"
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Trust Swift Macros (CI)
+        run: defaults write com.apple.dt.Xcode IDESkipMacroFingerprintValidation -bool YES
+
       - name: Deploy to TestFlight
         env:
           MATCH_GIT_URL:             ${{ secrets.MATCH_GIT_URL }}

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -59,7 +59,7 @@ platform :ios do
       output_directory: "build",
       output_name:      "OnboardingDemoApp.ipa",
       clean:            false,
-      xcargs:           "CODE_SIGNING_REQUIRED=YES CODE_SIGN_STYLE=Manual DEVELOPMENT_TEAM=#{ENV['TEAM_ID']} CODE_SIGN_IDENTITY='Apple Distribution'",
+      xcargs:           "CODE_SIGNING_REQUIRED=YES CODE_SIGN_STYLE=Manual DEVELOPMENT_TEAM=#{ENV['TEAM_ID']} CODE_SIGN_IDENTITY='Apple Distribution' CODE_SIGN_IDENTITY[sdk=macosx*]='' CODE_SIGNING_REQUIRED[sdk=macosx*]=NO PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]=''",
       xcodebuild_formatter: ""
     )
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -58,8 +58,8 @@ platform :ios do
       export_method:    "app-store",
       output_directory: "build",
       output_name:      "OnboardingDemoApp.ipa",
-      clean:            true,
-      xcargs:           "CODE_SIGNING_REQUIRED=YES"
+      clean:            false,
+      xcargs:           "CODE_SIGNING_REQUIRED=YES CODE_SIGN_STYLE=Manual"
     )
 
     # TestFlight 업로드

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -59,7 +59,7 @@ platform :ios do
       output_directory: "build",
       output_name:      "OnboardingDemoApp.ipa",
       clean:            false,
-      xcargs:           "CODE_SIGNING_REQUIRED=YES DEVELOPMENT_TEAM=#{ENV['TEAM_ID']} CODE_SIGN_IDENTITY='Apple Distribution' PROVISIONING_PROFILE_SPECIFIER='match AppStore com.teumteumeat.OnboardingDemoApp'",
+      xcargs:           "CODE_SIGNING_REQUIRED=YES CODE_SIGN_STYLE=Manual DEVELOPMENT_TEAM=#{ENV['TEAM_ID']} CODE_SIGN_IDENTITY='Apple Distribution'",
       xcodebuild_formatter: ""
     )
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -46,6 +46,9 @@ platform :ios do
       api_key:        api_key
     )
 
+    # tuist install (패키지 의존성 resolve)
+    sh("tuist install", chdir: File.expand_path("../#{DEMO_APP_PROJECT_DIR}", __dir__))
+
     # tuist generate
     sh("tuist generate --no-open", chdir: File.expand_path("../#{DEMO_APP_PROJECT_DIR}", __dir__))
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -47,7 +47,7 @@ platform :ios do
     )
 
     # tuist generate
-    sh("tuist generate --no-open", chdir: DEMO_APP_PROJECT_DIR)
+    sh("tuist generate --no-open", chdir: File.expand_path("../#{DEMO_APP_PROJECT_DIR}", __dir__))
 
     # 빌드 & 아카이브
     gym(
@@ -75,12 +75,21 @@ platform :ios do
   # ── 로컬 인증서 초기 세팅 (최초 1회) ───────────────────────
   desc "match 인증서 최초 생성 (로컬에서만 실행)"
   lane :setup_certs do
-    api_key = app_store_connect_api_key(
-      key_id:        ENV["ASC_API_KEY_ID"],
-      issuer_id:     ENV["ASC_ISSUER_ID"],
-      key_content:   ENV["ASC_API_KEY_CONTENT"],
-      is_key_content_base64: true
-    )
+    # 로컬: ASC_API_KEY_PATH(.p8 경로) 사용 / CI: base64 content 사용
+    api_key = if ENV["ASC_API_KEY_PATH"]
+      app_store_connect_api_key(
+        key_id:       ENV["ASC_API_KEY_ID"],
+        issuer_id:    ENV["ASC_ISSUER_ID"],
+        key_filepath: ENV["ASC_API_KEY_PATH"]
+      )
+    else
+      app_store_connect_api_key(
+        key_id:                ENV["ASC_API_KEY_ID"],
+        issuer_id:             ENV["ASC_ISSUER_ID"],
+        key_content:           ENV["ASC_API_KEY_CONTENT"],
+        is_key_content_base64: true
+      )
+    end
 
     match(
       type:           "appstore",

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -59,7 +59,7 @@ platform :ios do
       output_directory: "build",
       output_name:      "OnboardingDemoApp.ipa",
       clean:            false,
-      xcargs:           "CODE_SIGNING_REQUIRED=YES CODE_SIGN_STYLE=Manual",
+      xcargs:           "CODE_SIGNING_REQUIRED=YES CODE_SIGN_STYLE=Manual CODE_SIGN_IDENTITY='Apple Distribution' PROVISIONING_PROFILE_SPECIFIER='match AppStore com.teumteumeat.OnboardingDemoApp'",
       xcodebuild_formatter: ""
     )
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -59,7 +59,8 @@ platform :ios do
       output_directory: "build",
       output_name:      "OnboardingDemoApp.ipa",
       clean:            false,
-      xcargs:           "CODE_SIGNING_REQUIRED=YES CODE_SIGN_STYLE=Manual"
+      xcargs:           "CODE_SIGNING_REQUIRED=YES CODE_SIGN_STYLE=Manual",
+      xcodebuild_formatter: ""
     )
 
     # TestFlight 업로드

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -59,7 +59,7 @@ platform :ios do
       output_directory: "build",
       output_name:      "OnboardingDemoApp.ipa",
       clean:            false,
-      xcargs:           "CODE_SIGNING_REQUIRED=YES CODE_SIGN_STYLE=Manual CODE_SIGN_IDENTITY='Apple Distribution' PROVISIONING_PROFILE_SPECIFIER='match AppStore com.teumteumeat.OnboardingDemoApp'",
+      xcargs:           "CODE_SIGNING_REQUIRED=YES DEVELOPMENT_TEAM=#{ENV['TEAM_ID']} CODE_SIGN_IDENTITY='Apple Distribution' PROVISIONING_PROFILE_SPECIFIER='match AppStore com.teumteumeat.OnboardingDemoApp'",
       xcodebuild_formatter: ""
     )
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -46,11 +46,9 @@ platform :ios do
       api_key:        api_key
     )
 
-    # tuist install (패키지 의존성 resolve)
-    sh("tuist install", chdir: File.expand_path("../#{DEMO_APP_PROJECT_DIR}", __dir__))
-
-    # tuist generate
-    sh("tuist generate --no-open", chdir: File.expand_path("../#{DEMO_APP_PROJECT_DIR}", __dir__))
+    # tuist install & generate (절대 경로로 cd)
+    demo_app_path = File.expand_path("../#{DEMO_APP_PROJECT_DIR}", __dir__)
+    sh("cd '#{demo_app_path}' && tuist install && tuist generate --no-open")
 
     # 빌드 & 아카이브
     gym(


### PR DESCRIPTION
## 🎫 What is the PR?

OnboardingFeature DemoApp의 TestFlight 자동 배포 파이프라인을 구성했습니다.

## 🎫 Changes

- Fastlane `release_demo_app` lane 추가 — match → tuist generate → gym → TestFlight 업로드
- GitHub Actions 워크플로우 추가 — OnboardingFeature 변경 시 DemoApp 자동 배포
- Gemfile, Matchfile, Appfile 추가

## 🎫 Thoughts

**Swift 매크로 타겟 코드사이닝 충돌**
`CODE_SIGN_STYLE=Manual`을 xcargs로 글로벌하게 설정하면 PerceptionMacros 등 Swift 매크로 타겟과 충돌이 발생합니다.
매크로 타겟은 컴파일 타임에 macOS에서 실행되는 도구라 앱스토어 프로비저닝이 불필요하므로,
`[sdk=macosx*]` 조건부 xcargs로 macOS 타겟 코드사이닝만 비활성화했습니다.

**Xcode 26 미지원 이슈**
현재 GitHub-hosted runner(`macos-15`)는 Xcode 16.4까지만 지원합니다.
프로젝트 최소 지원 버전이 iOS 26이라 빌드가 되지 않으므로, 셀프 호스팅 러너 도입 전까지는 워크플로우가 비활성 상태입니다.

## 🎫 To Reviewers

- Fastfile의 `release_demo_app` lane 흐름(match → tuist → gym → pilot) 검토 부탁드립니다.
- 시크릿 키 목록: `MATCH_GIT_URL`, `MATCH_GIT_BASIC_AUTHORIZATION`, `MATCH_PASSWORD`, `ASC_API_KEY_ID`, `ASC_ISSUER_ID`, `ASC_API_KEY_CONTENT`, `TEAM_ID`

## 🖥️ 주요 코드 설명

`fastlane/Fastfile`

```ruby
gym(
  xcargs: "CODE_SIGNING_REQUIRED=YES CODE_SIGN_STYLE=Manual \
           DEVELOPMENT_TEAM=#{ENV['TEAM_ID']} \
           CODE_SIGN_IDENTITY='Apple Distribution' \
           CODE_SIGN_IDENTITY[sdk=macosx*]='' \
           CODE_SIGNING_REQUIRED[sdk=macosx*]=NO \
           PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]=''"
)
```

## ✅ Check List

- Merge 대상 브랜치가 올바른가?
- 최종 코드가 에러 없이 잘 동작하는가?
- 전체 변경사항이 500줄을 넘지 않는가?

## 🎫 Related Issues

- Resolved: #52