### PR TITLE
Qa/#58

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@
 ._.DS_Store
 **/.DS_Store
 **/._.DS_Store
+
+# Markdown files
+*.md
 *.xcconfig
 
 # Firebase Configuration Files

--- a/TeumTeumEat/Packages/DesignSystem/Sources/DesignSystem/Components/Buttons/TTETabButton.swift
+++ b/TeumTeumEat/Packages/DesignSystem/Sources/DesignSystem/Components/Buttons/TTETabButton.swift
@@ -30,6 +30,7 @@ public struct TTETabButton: View {
     public let icon: Image
     public let size: TabButtonSize
     public let isSelected: Bool
+    public let customIconSize: CGFloat?
 
     // 커스텀 색상
     public let selectedBackgroundColor: Color?
@@ -43,6 +44,7 @@ public struct TTETabButton: View {
         icon: Image,
         size: TabButtonSize = .large,
         isSelected: Bool = false,
+        customIconSize: CGFloat? = nil,
         selectedBackgroundColor: Color? = nil,
         unselectedBackgroundColor: Color? = nil,
         selectedIconColor: Color? = nil,
@@ -52,13 +54,14 @@ public struct TTETabButton: View {
         self.icon = icon
         self.size = size
         self.isSelected = isSelected
+        self.customIconSize = customIconSize
         self.selectedBackgroundColor = selectedBackgroundColor
         self.unselectedBackgroundColor = unselectedBackgroundColor
         self.selectedIconColor = selectedIconColor
         self.unselectedIconColor = unselectedIconColor
         self.action = action
     }
-    
+
     public var body: some View {
         Button(action: action) {
             ZStack {
@@ -66,13 +69,13 @@ public struct TTETabButton: View {
                 Circle()
                     .fill(backgroundColor)
                     .frame(width: size.buttonSize, height: size.buttonSize)
-                
+
                 // 아이콘
                 icon
                     .resizable()
                     .renderingMode(.template)
                     .foregroundColor(iconColor)
-                    .frame(width: size.iconSize, height: size.iconSize)
+                    .frame(width: customIconSize ?? size.iconSize, height: customIconSize ?? size.iconSize)
             }
         }
     }

--- a/TeumTeumEat/Packages/DesignSystem/Sources/DesignSystem/Components/TTEToastModifier.swift
+++ b/TeumTeumEat/Packages/DesignSystem/Sources/DesignSystem/Components/TTEToastModifier.swift
@@ -1,0 +1,46 @@
+//
+//  TTEToastModifier.swift
+//  DesignSystem
+//
+//  Created by 임재현 on 6/21/26.
+//
+
+import SwiftUI
+
+public struct TTEToastModifier: ViewModifier {
+    @Binding public var isPresented: Bool
+    public let message: String
+
+    public func body(content: Content) -> some View {
+        ZStack(alignment: .bottom) {
+            content
+
+            if isPresented {
+                Text(message)
+                    .font(.system(size: 14, weight: .medium))
+                    .foregroundColor(.white)
+                    .padding(.horizontal, 20)
+                    .padding(.vertical, 12)
+                    .background(Color.black.opacity(0.8))
+                    .cornerRadius(10)
+                    .padding(.horizontal, 32)
+                    .padding(.bottom, 60)
+                    .transition(.opacity.combined(with: .move(edge: .bottom)))
+                    .onAppear {
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 2.5) {
+                            withAnimation(.easeOut(duration: 0.3)) {
+                                isPresented = false
+                            }
+                        }
+                    }
+            }
+        }
+        .animation(.easeInOut(duration: 0.3), value: isPresented)
+    }
+}
+
+public extension View {
+    func tteToast(isPresented: Binding<Bool>, message: String) -> some View {
+        self.modifier(TTEToastModifier(isPresented: isPresented, message: message))
+    }
+}

--- a/TeumTeumEat/Packages/OnboardingFeature/Sources/OnboardingFeature/Screens/CategorySelection/CategorySelectionFeature.swift
+++ b/TeumTeumEat/Packages/OnboardingFeature/Sources/OnboardingFeature/Screens/CategorySelection/CategorySelectionFeature.swift
@@ -64,12 +64,15 @@ public struct CategorySelectionFeature {
         // currentDetailCategories → name 사용
         public var currentDetailCategories: [CategoryResponse] {
             guard let root = selectedRootCategory,
-                  let main = selectedMainCategory,
-                  let sub = selectedSubCategory else { return [] }
-            return categories.filter {
-                $0.mainCategory == root &&
-                $0.subCategory == main &&
-                $0.pathComponents[safe: 3] == sub
+                  let main = selectedMainCategory else { return [] }
+            let base = categories.filter {
+                $0.mainCategory == root && $0.subCategory == main
+            }
+            if let sub = selectedSubCategory {
+                return base.filter { $0.pathComponents[safe: 3] == sub }
+            } else {
+                // subCategory 단계가 없는 depth-2 경로 (/IT/iOS 개발)
+                return base.filter { $0.pathComponents[safe: 3] == nil }
             }
         }
         
@@ -109,7 +112,7 @@ public struct CategorySelectionFeature {
         case delegate(Delegate)
 
         public enum Delegate {
-            case completed(root: String, main: String, sub: String, detail: CategoryResponse)
+            case completed(root: String, main: String, sub: String?, detail: CategoryResponse)
             case backToContentSelection
             case saveProgress(root: String?, main: String?, sub: String?, detail: CategoryResponse?)
         }
@@ -184,7 +187,12 @@ public struct CategorySelectionFeature {
                     )))
                     
                 case .detailCategory:
-                    state.currentStep = .subCategory
+                    // subCategory 단계를 거치지 않은 경우(depth-2) mainCategory로 복귀
+                    if state.currentSubCategories.isEmpty {
+                        state.currentStep = .mainCategory
+                    } else {
+                        state.currentStep = .subCategory
+                    }
                     return .send(.delegate(.saveProgress(
                         root: state.selectedRootCategory,
                         main: state.selectedMainCategory,
@@ -198,23 +206,28 @@ public struct CategorySelectionFeature {
                 case .rootCategory:
                     state.currentStep = .mainCategory
                     return .none
-                    
+
                 case .mainCategory:
-                    state.currentStep = .subCategory
+                    // subCategory가 없는 depth-2 경로면 detailCategory로 바로 이동
+                    if state.currentSubCategories.isEmpty {
+                        state.selectedSubCategory = nil
+                        state.currentStep = .detailCategory
+                    } else {
+                        state.currentStep = .subCategory
+                    }
                     return .none
-                    
+
                 case .subCategory:
                     state.currentStep = .detailCategory
                     return .none
-                    
+
                 case .detailCategory:
                     guard let root = state.selectedRootCategory,
                           let main = state.selectedMainCategory,
-                          let sub = state.selectedSubCategory,
                           let detail = state.selectedDetailCategory else {
                         return .none
                     }
-                    return .send(.delegate(.completed(root: root, main: main, sub: sub, detail: detail)))
+                    return .send(.delegate(.completed(root: root, main: main, sub: state.selectedSubCategory, detail: detail)))
                 }
                 
             case .rootCategorySelected(let category):

--- a/TeumTeumEat/Packages/OnboardingFeature/Sources/OnboardingFeature/Screens/DurationSelectButton.swift
+++ b/TeumTeumEat/Packages/OnboardingFeature/Sources/OnboardingFeature/Screens/DurationSelectButton.swift
@@ -17,11 +17,15 @@ struct DurationSelectButton: View {
         Button(action: action) {
             Text(text)
                 .stSemibold16()
-                .foregroundColor(isSelected ? .white : .gray700)
+                .foregroundColor(isSelected ? .blue500 : .gray700)
                 .frame(maxWidth: .infinity)
                 .frame(height: 50)
-                .background(isSelected ? Color.blue500 : Color.gray100)
+                .background(Color.white)
                 .cornerRadius(12)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 12)
+                        .stroke(isSelected ? Color.blue500 : Color.gray200, lineWidth: 1.5)
+                )
         }
     }
 }

--- a/TeumTeumEat/Packages/OnboardingFeature/Sources/OnboardingFeature/Screens/Loading/OnboardingLoadingFeature.swift
+++ b/TeumTeumEat/Packages/OnboardingFeature/Sources/OnboardingFeature/Screens/Loading/OnboardingLoadingFeature.swift
@@ -456,7 +456,7 @@ public struct OnboardingLoadingFeature {
                     TextState("정말 취소하시겠어요?")
                 } actions: {
                     ButtonState(role: .destructive, action: .confirmCancel) { TextState("취소") }
-                    ButtonState(action: .goBack) { TextState("돌아가기") }
+                    ButtonState(role: .cancel, action: .goBack) { TextState("돌아가기") }
                 } message: {
                     TextState("처음부터 다시 입력해야 합니다.")
                 }

--- a/TeumTeumEat/Packages/OnboardingFeature/Sources/OnboardingFeature/Screens/Loading/OnboardingLoadingFeature.swift
+++ b/TeumTeumEat/Packages/OnboardingFeature/Sources/OnboardingFeature/Screens/Loading/OnboardingLoadingFeature.swift
@@ -30,6 +30,7 @@ public struct OnboardingLoadingFeature {
         public var sseProgress: Double = 0.0
         public var remainingSeconds: Int? = nil
         public var totalInitialMs: Int? = nil
+        public var isOverdue: Bool = false
 
         @Presents public var errorAlert: AlertState<Action.ErrorAlert>?
         @Presents public var confirmCancelAlert: AlertState<Action.ConfirmCancelAlert>?
@@ -85,6 +86,7 @@ public struct OnboardingLoadingFeature {
         case sseStartRequested(goalId: Int, documentId: Int)
         case sseEventReceived(SSEDocumentStatus)
         case sseConnectionFailed(String)
+        case sseTimeoutTriggered
         case tickTimer
 
         case errorAlert(PresentationAction<ErrorAlert>)
@@ -110,7 +112,10 @@ public struct OnboardingLoadingFeature {
     private enum CancelID: Hashable {
         case sseStream
         case timer
+        case sseTimeout
     }
+
+    private static let clientTimeoutSeconds: Int = 300 // 5분
 
     @Dependency(\.onboardingAPIClient) var apiClient
 
@@ -257,7 +262,7 @@ public struct OnboardingLoadingFeature {
                 state.loadingSteps[1].isCompleted = true
                 print("[SSE] 연결 시작 - goalId: \(goalId), documentId: \(documentId)")
 
-                return .run { send in
+                let sseEffect = Effect<Action>.run { send in
                     do {
                         for try await event in apiClient.connectDocumentSSE(
                             goalId,
@@ -274,6 +279,14 @@ public struct OnboardingLoadingFeature {
                 }
                 .cancellable(id: CancelID.sseStream)
 
+                let timeoutEffect = Effect<Action>.run { send in
+                    try await Task.sleep(for: .seconds(OnboardingLoadingFeature.clientTimeoutSeconds))
+                    await send(.sseTimeoutTriggered)
+                }
+                .cancellable(id: CancelID.sseTimeout)
+
+                return .merge(sseEffect, timeoutEffect)
+
             case .sseEventReceived(let event):
                 switch event {
                 case .connected:
@@ -286,14 +299,15 @@ public struct OnboardingLoadingFeature {
                 case .processing(let remainMs):
                     print("[SSE] 처리 중 - 남은 시간: \(remainMs)ms")
 
-                    // remain: 0 → 서버가 잔여 시간을 모르는 경우, indeterminate 처리
+                    // remain_ms = 0 → 서버가 예상 시간을 모름, 99%에서 대기
                     guard remainMs > 0 else {
-                        if state.sseProgress < 0.85 {
-                            state.sseProgress = min(state.sseProgress + 0.05, 0.85)
-                        }
-                        return .none
+                        state.sseProgress = 0.99
+                        state.isOverdue = true
+                        state.remainingSeconds = nil
+                        return .cancel(id: CancelID.timer)
                     }
 
+                    state.isOverdue = false
                     if state.totalInitialMs == nil {
                         state.totalInitialMs = remainMs
                     }
@@ -314,10 +328,12 @@ public struct OnboardingLoadingFeature {
                     print("[SSE] 완료")
                     state.sseProgress = 1.0
                     state.remainingSeconds = 0
+                    state.isOverdue = false
                     state.loadingSteps[2].isCompleted = true
                     state.apiCompleted = true
                     return .merge(
                         .cancel(id: CancelID.timer),
+                        .cancel(id: CancelID.sseTimeout),
                         .send(.checkCompletion)
                     )
 
@@ -326,6 +342,7 @@ public struct OnboardingLoadingFeature {
                     return .merge(
                         .cancel(id: CancelID.timer),
                         .cancel(id: CancelID.sseStream),
+                        .cancel(id: CancelID.sseTimeout),
                         .send(.apiFailure(.serverError(
                             code: "SSE-FAILED",
                             message: reason.userMessage,
@@ -337,11 +354,26 @@ public struct OnboardingLoadingFeature {
 
             case .sseConnectionFailed(let message):
                 print("[SSE] 연결 실패: \(message)")
-                return .send(.apiFailure(.serverError(
-                    code: "SSE-CONNECTION",
-                    message: message,
-                    details: nil
-                )))
+                return .merge(
+                    .cancel(id: CancelID.sseTimeout),
+                    .send(.apiFailure(.serverError(
+                        code: "SSE-CONNECTION",
+                        message: message,
+                        details: nil
+                    )))
+                )
+
+            case .sseTimeoutTriggered:
+                print("[SSE] 클라이언트 타임아웃 (\(OnboardingLoadingFeature.clientTimeoutSeconds)초)")
+                return .merge(
+                    .cancel(id: CancelID.sseStream),
+                    .cancel(id: CancelID.timer),
+                    .send(.apiFailure(.serverError(
+                        code: "SSE-CLIENT-TIMEOUT",
+                        message: "처리 시간이 초과되었습니다. 잠시 후 다시 시도해주세요.",
+                        details: nil
+                    )))
+                )
 
             case .tickTimer:
                 guard let remaining = state.remainingSeconds, remaining > 0 else { return .none }
@@ -398,9 +430,11 @@ public struct OnboardingLoadingFeature {
                     state.totalInitialMs = nil
                     state.sseGoalId = nil
                     state.sseDocumentId = nil
+                    state.isOverdue = false
                     return .merge(
                         .cancel(id: CancelID.sseStream),
                         .cancel(id: CancelID.timer),
+                        .cancel(id: CancelID.sseTimeout),
                         .send(.submitOnboardingData)
                     )
                 } else {

--- a/TeumTeumEat/Packages/OnboardingFeature/Sources/OnboardingFeature/Screens/Loading/OnboardingLoadingView.swift
+++ b/TeumTeumEat/Packages/OnboardingFeature/Sources/OnboardingFeature/Screens/Loading/OnboardingLoadingView.swift
@@ -53,7 +53,11 @@ public struct OnboardingLoadingView: View {
                     .foregroundColor(.primary)
 
                 if store.isFileUpload {
-                    if let remaining = store.remainingSeconds, remaining > 0 {
+                    if store.isOverdue {
+                        Text("시간이 조금 더 걸리고 있어요...")
+                            .font(.system(size: 16))
+                            .foregroundColor(.gray)
+                    } else if let remaining = store.remainingSeconds, remaining > 0 {
                         Text("약 \(remaining)초 남았어요")
                             .font(.system(size: 16))
                             .foregroundColor(.gray)

--- a/TeumTeumEat/TeumTeumEat.xcodeproj/project.pbxproj
+++ b/TeumTeumEat/TeumTeumEat.xcodeproj/project.pbxproj
@@ -10,14 +10,16 @@
 		4663663E2FC477750043EAEB /* DesignSystem in Frameworks */ = {isa = PBXBuildFile; productRef = 4663663D2FC477750043EAEB /* DesignSystem */; };
 		466366402FC477800043EAEB /* CoreNetwork in Frameworks */ = {isa = PBXBuildFile; productRef = 4663663F2FC477800043EAEB /* CoreNetwork */; };
 		466366432FC52DB20043EAEB /* OnboardingFeature in Frameworks */ = {isa = PBXBuildFile; productRef = 466366422FC52DB20043EAEB /* OnboardingFeature */; };
+		4679DBE02FEABD5100932776 /* FirebaseAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = 4679DBDF2FEABD5100932776 /* FirebaseAnalytics */; };
+		4679DBE22FEABD5100932776 /* FirebaseCore in Frameworks */ = {isa = PBXBuildFile; productRef = 4679DBE12FEABD5100932776 /* FirebaseCore */; };
+		4679DBE42FEABD5100932776 /* FirebaseCrashlytics in Frameworks */ = {isa = PBXBuildFile; productRef = 4679DBE32FEABD5100932776 /* FirebaseCrashlytics */; };
+		4679DBE62FEABD5100932776 /* FirebaseMessaging in Frameworks */ = {isa = PBXBuildFile; productRef = 4679DBE52FEABD5100932776 /* FirebaseMessaging */; };
+		4679DBE82FEABD5100932776 /* FirebaseRemoteConfig in Frameworks */ = {isa = PBXBuildFile; productRef = 4679DBE72FEABD5100932776 /* FirebaseRemoteConfig */; };
 		46AE2AA12F0125BD0061B2EE /* KakaoSDK in Frameworks */ = {isa = PBXBuildFile; productRef = 46AE2AA02F0125BD0061B2EE /* KakaoSDK */; };
 		46AE2AA32F0125BD0061B2EE /* KakaoSDKAuth in Frameworks */ = {isa = PBXBuildFile; productRef = 46AE2AA22F0125BD0061B2EE /* KakaoSDKAuth */; };
 		46C646952F6982AC005BA910 /* GoogleMobileAds in Frameworks */ = {isa = PBXBuildFile; productRef = 46C646942F6982AC005BA910 /* GoogleMobileAds */; };
 		46C6475C2F06B813009F030A /* MarkdownUI in Frameworks */ = {isa = PBXBuildFile; productRef = 46C6475B2F06B813009F030A /* MarkdownUI */; };
 		46C647632F06D960009F030A /* Lottie in Frameworks */ = {isa = PBXBuildFile; productRef = 46C647622F06D960009F030A /* Lottie */; };
-		46C648C42F6C4568005BA910 /* FirebaseRemoteConfig in Frameworks */ = {isa = PBXBuildFile; productRef = 46C648C32F6C4568005BA910 /* FirebaseRemoteConfig */; };
-		46C65A642F13E1FA009F030A /* FirebaseCore in Frameworks */ = {isa = PBXBuildFile; productRef = 46C65A632F13E1FA009F030A /* FirebaseCore */; };
-		46C65A6C2F13EB11009F030A /* FirebaseMessaging in Frameworks */ = {isa = PBXBuildFile; productRef = 46C65A6B2F13EB11009F030A /* FirebaseMessaging */; };
 		46E995172F1E6C3E009946C1 /* InfoPlist.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 46E995162F1E6C3E009946C1 /* InfoPlist.xcstrings */; };
 		46FE6B842EEACE0B009E626A /* ComposableArchitecture in Frameworks */ = {isa = PBXBuildFile; productRef = 46FE6B832EEACE0B009E626A /* ComposableArchitecture */; };
 /* End PBXBuildFile section */
@@ -82,17 +84,19 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				46C648C42F6C4568005BA910 /* FirebaseRemoteConfig in Frameworks */,
 				46C647632F06D960009F030A /* Lottie in Frameworks */,
 				46FE6B842EEACE0B009E626A /* ComposableArchitecture in Frameworks */,
-				46C65A6C2F13EB11009F030A /* FirebaseMessaging in Frameworks */,
+				4679DBE22FEABD5100932776 /* FirebaseCore in Frameworks */,
+				4679DBE82FEABD5100932776 /* FirebaseRemoteConfig in Frameworks */,
 				46AE2AA12F0125BD0061B2EE /* KakaoSDK in Frameworks */,
 				466366402FC477800043EAEB /* CoreNetwork in Frameworks */,
 				4663663E2FC477750043EAEB /* DesignSystem in Frameworks */,
 				46C646952F6982AC005BA910 /* GoogleMobileAds in Frameworks */,
 				466366432FC52DB20043EAEB /* OnboardingFeature in Frameworks */,
+				4679DBE62FEABD5100932776 /* FirebaseMessaging in Frameworks */,
 				46AE2AA32F0125BD0061B2EE /* KakaoSDKAuth in Frameworks */,
-				46C65A642F13E1FA009F030A /* FirebaseCore in Frameworks */,
+				4679DBE42FEABD5100932776 /* FirebaseCrashlytics in Frameworks */,
+				4679DBE02FEABD5100932776 /* FirebaseAnalytics in Frameworks */,
 				46C6475C2F06B813009F030A /* MarkdownUI in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -168,13 +172,15 @@
 				46AE2AA22F0125BD0061B2EE /* KakaoSDKAuth */,
 				46C6475B2F06B813009F030A /* MarkdownUI */,
 				46C647622F06D960009F030A /* Lottie */,
-				46C65A632F13E1FA009F030A /* FirebaseCore */,
-				46C65A6B2F13EB11009F030A /* FirebaseMessaging */,
 				46C646942F6982AC005BA910 /* GoogleMobileAds */,
-				46C648C32F6C4568005BA910 /* FirebaseRemoteConfig */,
 				4663663D2FC477750043EAEB /* DesignSystem */,
 				4663663F2FC477800043EAEB /* CoreNetwork */,
 				466366422FC52DB20043EAEB /* OnboardingFeature */,
+				4679DBDF2FEABD5100932776 /* FirebaseAnalytics */,
+				4679DBE12FEABD5100932776 /* FirebaseCore */,
+				4679DBE32FEABD5100932776 /* FirebaseCrashlytics */,
+				4679DBE52FEABD5100932776 /* FirebaseMessaging */,
+				4679DBE72FEABD5100932776 /* FirebaseRemoteConfig */,
 			);
 			productName = TeumTeumEat;
 			productReference = 46FE666E2EE1770E009E626A /* TeumTeumEat.app */;
@@ -264,11 +270,11 @@
 				46AE2A9F2F0125BD0061B2EE /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */,
 				46C6475A2F06B813009F030A /* XCRemoteSwiftPackageReference "swift-markdown-ui" */,
 				46C647612F06D960009F030A /* XCRemoteSwiftPackageReference "lottie-ios" */,
-				46C65A622F13E1FA009F030A /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
 				46C646932F6982AC005BA910 /* XCRemoteSwiftPackageReference "swift-package-manager-google-mobile-ads" */,
 				46F2FFC72FC3054B001A9707 /* XCLocalSwiftPackageReference "Packages/DesignSystem" */,
 				46F2FFC82FC307A8001A9707 /* XCLocalSwiftPackageReference "Packages/CoreNetwork" */,
 				466366412FC52DB20043EAEB /* XCLocalSwiftPackageReference "Packages/OnboardingFeature" */,
+				4679DBDE2FEABD5100932776 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 46FE666F2EE1770E009E626A /* Products */;
@@ -676,6 +682,14 @@
 /* End XCLocalSwiftPackageReference section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		4679DBDE2FEABD5100932776 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/firebase/firebase-ios-sdk";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 12.15.0;
+			};
+		};
 		46AE2A9F2F0125BD0061B2EE /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/kakao/kakao-ios-sdk";
@@ -708,14 +722,6 @@
 				minimumVersion = 4.5.2;
 			};
 		};
-		46C65A622F13E1FA009F030A /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/firebase/firebase-ios-sdk";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 12.7.0;
-			};
-		};
 		46FE6B822EEACE0B009E626A /* XCRemoteSwiftPackageReference "swift-composable-architecture" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/pointfreeco/swift-composable-architecture.git";
@@ -741,6 +747,31 @@
 			isa = XCSwiftPackageProductDependency;
 			productName = OnboardingFeature;
 		};
+		4679DBDF2FEABD5100932776 /* FirebaseAnalytics */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 4679DBDE2FEABD5100932776 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseAnalytics;
+		};
+		4679DBE12FEABD5100932776 /* FirebaseCore */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 4679DBDE2FEABD5100932776 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseCore;
+		};
+		4679DBE32FEABD5100932776 /* FirebaseCrashlytics */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 4679DBDE2FEABD5100932776 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseCrashlytics;
+		};
+		4679DBE52FEABD5100932776 /* FirebaseMessaging */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 4679DBDE2FEABD5100932776 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseMessaging;
+		};
+		4679DBE72FEABD5100932776 /* FirebaseRemoteConfig */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 4679DBDE2FEABD5100932776 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseRemoteConfig;
+		};
 		46AE2AA02F0125BD0061B2EE /* KakaoSDK */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 46AE2A9F2F0125BD0061B2EE /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */;
@@ -765,21 +796,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 46C647612F06D960009F030A /* XCRemoteSwiftPackageReference "lottie-ios" */;
 			productName = Lottie;
-		};
-		46C648C32F6C4568005BA910 /* FirebaseRemoteConfig */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 46C65A622F13E1FA009F030A /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
-			productName = FirebaseRemoteConfig;
-		};
-		46C65A632F13E1FA009F030A /* FirebaseCore */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 46C65A622F13E1FA009F030A /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
-			productName = FirebaseCore;
-		};
-		46C65A6B2F13EB11009F030A /* FirebaseMessaging */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 46C65A622F13E1FA009F030A /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
-			productName = FirebaseMessaging;
 		};
 		46FE6B832EEACE0B009E626A /* ComposableArchitecture */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/TeumTeumEat/TeumTeumEat.xcodeproj/project.pbxproj
+++ b/TeumTeumEat/TeumTeumEat.xcodeproj/project.pbxproj
@@ -495,7 +495,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.7;
+				MARKETING_VERSION = 1.0.8;
 				PRODUCT_BUNDLE_IDENTIFIER = com.TeumTeumEat;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -534,7 +534,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.7;
+				MARKETING_VERSION = 1.0.8;
 				PRODUCT_BUNDLE_IDENTIFIER = com.TeumTeumEat;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/TeumTeumEat/TeumTeumEat.xcodeproj/xcshareddata/xcschemes/TeumTeumEat.xcscheme
+++ b/TeumTeumEat/TeumTeumEat.xcodeproj/xcshareddata/xcschemes/TeumTeumEat.xcscheme
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2630"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "46FE666D2EE1770E009E626A"
+               BuildableName = "TeumTeumEat.app"
+               BlueprintName = "TeumTeumEat"
+               ReferencedContainer = "container:TeumTeumEat.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "46FE667A2EE17711009E626A"
+               BuildableName = "TeumTeumEatTests.xctest"
+               BlueprintName = "TeumTeumEatTests"
+               ReferencedContainer = "container:TeumTeumEat.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "46FE66842EE17711009E626A"
+               BuildableName = "TeumTeumEatUITests.xctest"
+               BlueprintName = "TeumTeumEatUITests"
+               ReferencedContainer = "container:TeumTeumEat.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "46FE666D2EE1770E009E626A"
+            BuildableName = "TeumTeumEat.app"
+            BlueprintName = "TeumTeumEat"
+            ReferencedContainer = "container:TeumTeumEat.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "-FIRAnalyticsDebugDisabled"
+            isEnabled = "YES">
+         </CommandLineArgument>
+      </CommandLineArguments>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "46FE666D2EE1770E009E626A"
+            BuildableName = "TeumTeumEat.app"
+            BlueprintName = "TeumTeumEat"
+            ReferencedContainer = "container:TeumTeumEat.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/TeumTeumEat/TeumTeumEat/App/TeumTeumEatApp.swift
+++ b/TeumTeumEat/TeumTeumEat/App/TeumTeumEatApp.swift
@@ -13,6 +13,7 @@ import UserNotifications
 import FirebaseCore
 import FirebaseMessaging
 import GoogleMobileAds
+import FirebaseAnalytics
 
 @main
 struct TeumTeumEatApp: App {

--- a/TeumTeumEat/TeumTeumEat/Features/APIError.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/APIError.swift
@@ -132,6 +132,21 @@ enum APIError: Error, LocalizedError, Equatable {
         return false
     }
     
+    // 에러 오버레이에 표시할 사용자 친화적 메시지
+    var overlayMessage: String {
+        switch self {
+        case .networkError:
+            return "인터넷 연결을 확인하고 다시 시도해 주세요."
+        case .serverError(let code, _, _):
+            if code.hasPrefix("5") || code == "COMMON-007" {
+                return "서버 점검 중이거나 일시적인 오류입니다."
+            }
+            return userFriendlyMessage
+        default:
+            return "에러가 발생했습니다."
+        }
+    }
+
     static func == (lhs: APIError, rhs: APIError) -> Bool {
         switch (lhs, rhs) {
         case (.invalidURL, .invalidURL):

--- a/TeumTeumEat/TeumTeumEat/Features/App/AppFeature.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/App/AppFeature.swift
@@ -94,10 +94,10 @@ struct AppFeature {
                 
             // Onboarding Delegate
             case .onboarding(.complete(.startButtonTapped)):
-                // 온보딩 완료 → TODO: 메인 화면 (나중에 구현)
                 state.onboarding = nil
                 print("온보딩 완료 - 메인 화면으로 이동 예정")
                 UserDefaultsManager.isOnboardingCompleted = true
+                AnalyticsManager.logOnboardingComplete()
                 state.mainTab = MainTabFeature.State()
                 return .none
                 

--- a/TeumTeumEat/TeumTeumEat/Features/Login/LoginFeature.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/Login/LoginFeature.swift
@@ -20,6 +20,7 @@ struct LoginFeature {
         var pendingProvider: SocialProvider?
         var pendingName: String?
         var showTermsSheet = false
+        var isNewUser = false
     }
     
     enum SocialProvider: String {
@@ -133,30 +134,38 @@ struct LoginFeature {
                         state.errorMessage = "응답 데이터가 없습니다."
                         return .none
                     }
-                    
+
                     // 토큰 저장
                     print("토큰 저장 중...")
                     KeyChainManager.shared.saveAccessToken(data.accessToken)
                     KeyChainManager.shared.saveRefreshToken(data.refreshToken)
                     print("토큰 저장 완료")
-                    
+
+                    // Analytics
+                    let method = state.pendingProvider?.rawValue.lowercased() ?? "unknown"
+                    if state.isNewUser {
+                        AnalyticsManager.logSignUp(method: method)
+                    } else {
+                        AnalyticsManager.logLogin(method: method)
+                    }
+
                     print("다음 화면 분기:")
                     if data.isOnboardingCompleted {
                         print("   → 메인 화면 (온보딩 완료)")
                     } else {
                         print("   → 온보딩 화면 (온보딩 미완료)")
                     }
-                    
+
                     return .send(.delegate(.loginSuccess(
                         accessToken: data.accessToken,
                         refreshToken: data.refreshToken,
                         isOnboardingCompleted: data.isOnboardingCompleted
                     )))
-                    
+
                 } else if response.code == "AUTH-006" {
                     // 신규 유저 → 약관 동의 필요
-                    // pendingIdToken은 이미 state에 저장되어 있음
                     print("약관 동의 필요 (신규 유저)")
+                    state.isNewUser = true
                     state.showTermsSheet = true
                     return .none
 

--- a/TeumTeumEat/TeumTeumEat/Features/Login/LoginView.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/Login/LoginView.swift
@@ -73,12 +73,6 @@ struct LoginView: View {
             .padding(.horizontal, 20)
             .padding(.bottom, 50)
             
-            if let errorMessage = store.errorMessage {
-                Text(errorMessage)
-                    .font(.caption)
-                    .foregroundColor(.red)
-                    .padding(.top, 8)
-            }
         }
         .padding()
         .background(.white)

--- a/TeumTeumEat/TeumTeumEat/Features/MainTab/MainTab/Home/CouponModalView.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/MainTab/MainTab/Home/CouponModalView.swift
@@ -84,7 +84,7 @@ struct CouponModalView: View {
                 }
                 .disabled(!canIssueCoupon)
             }
-            .padding(.horizontal, 20)
+            .padding(.horizontal, 28)
             .padding(.bottom, 28)
         }
         .background(Color.white)

--- a/TeumTeumEat/TeumTeumEat/Features/MainTab/MainTab/Home/CouponModalView.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/MainTab/MainTab/Home/CouponModalView.swift
@@ -65,10 +65,10 @@ struct CouponModalView: View {
                 Button(action: onUse) {
                     Text("쿠폰 사용")
                         .font(.system(size: 16, weight: .semibold))
-                        .foregroundColor(couponCount > 0 ? .gray600 : Color.gray300)
+                        .foregroundColor(couponCount > 0 ? .blue500 : Color.gray300)
                         .frame(maxWidth: .infinity)
                         .frame(height: 50)
-                        .background(Color.gray300.opacity(0.4))
+                        .background(couponCount > 0 ? Color.blue100 : Color.gray300.opacity(0.4))
                         .cornerRadius(10)
                 }
                 .disabled(couponCount == 0)

--- a/TeumTeumEat/TeumTeumEat/Features/MainTab/MainTab/Home/HomeFeature.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/MainTab/MainTab/Home/HomeFeature.swift
@@ -31,6 +31,12 @@ struct HomeFeature {
         var isLoading: Bool = false
         var errorMessage: String?
 
+        var showErrorOverlay: Bool = false
+        var errorOverlayMessage: String = ""
+        var isRetryingError: Bool = false
+        var retryCount: Int = 0
+        var showRetryToast: Bool = false
+
         var showCouponModal: Bool = false
         var isUsingCoupon: Bool = false
 
@@ -82,6 +88,9 @@ struct HomeFeature {
         // Step 4: 퀴즈 조회
         case fetchQuizzesResponse(Result<[UserQuiz], Error>)
         
+        case retryFromErrorOverlay
+        case dismissErrorOverlay
+        case retryToastDismissed
         case settingTapped
         case toggleQuizStatus
         case characterEatTapped
@@ -115,6 +124,9 @@ struct HomeFeature {
             case .onAppear:
                 state.isLoading = true
                 state.errorMessage = nil
+                state.showErrorOverlay = false
+                state.retryCount = 0
+                state.showRetryToast = false
                 
                 // 병렬 처리: 캘린더 조회 + 목표 조회
                 let now = Date()
@@ -156,6 +168,9 @@ struct HomeFeature {
                 
             // Step 1 완료 → Step 2 시작
             case .fetchCurrentGoalResponse(.success(let goal)):
+                state.showErrorOverlay = false
+                state.isRetryingError = false
+                state.retryCount = 0
                 state.isExpired = goal.isExpired
                 if goal.isExpired {
                     state.currentGoal = goal
@@ -194,7 +209,10 @@ struct HomeFeature {
                 
             case .fetchCurrentGoalResponse(.failure(let error)):
                 state.isLoading = false
-                state.errorMessage = "목표 조회 실패: \(error.localizedDescription)"
+                let overlayMsg = (error as? APIError)?.overlayMessage ?? "에러가 발생했습니다."
+                state.errorOverlayMessage = overlayMsg
+                state.showErrorOverlay = true
+                state.isRetryingError = false
                 print("[Home] Step1 실패: \(error)")
                 return .none
                 
@@ -239,7 +257,10 @@ struct HomeFeature {
                     return .none
                 }
                 state.isLoading = false
-                state.errorMessage = "퀴즈 상태 조회 실패: \(error.localizedDescription)"
+                let overlayMsg = (error as? APIError)?.overlayMessage ?? "에러가 발생했습니다."
+                state.errorOverlayMessage = overlayMsg
+                state.showErrorOverlay = true
+                state.isRetryingError = false
                 print("[Home] Step2 실패: \(error)")
                 return .none
                 
@@ -303,6 +324,48 @@ struct HomeFeature {
                 print("[Home] Step4 실패: \(error)")
                 return .none
                 
+            case .retryFromErrorOverlay:
+                state.retryCount += 1
+                if state.retryCount >= 2 {
+                    state.showRetryToast = true
+                }
+                state.isRetryingError = true
+                state.isLoading = true
+                state.errorMessage = nil
+
+                let now = Date()
+                let calendar = Calendar.current
+                let year = calendar.component(.year, from: now)
+                let month = calendar.component(.month, from: now)
+
+                return .merge(
+                    .run { send in
+                        do {
+                            let calendarData = try await apiClient.fetchCalendarHistory(year: year, month: month)
+                            await send(.fetchCalendarHistoryResponse(.success(calendarData)))
+                        } catch {
+                            await send(.fetchCalendarHistoryResponse(.failure(error)))
+                        }
+                    },
+                    .run { send in
+                        do {
+                            let goal = try await apiClient.fetchCurrentGoal()
+                            await send(.fetchCurrentGoalResponse(.success(goal)))
+                        } catch {
+                            await send(.fetchCurrentGoalResponse(.failure(error)))
+                        }
+                    }
+                )
+
+            case .dismissErrorOverlay:
+                state.showErrorOverlay = false
+                state.isRetryingError = false
+                return .none
+
+            case .retryToastDismissed:
+                state.showRetryToast = false
+                return .none
+
             case .settingTapped:
                 return .send(.delegate(.openMyPageRequested))
 
@@ -543,6 +606,27 @@ struct HomeView: View {
                 }
             }
             .animation(.spring(response: 0.3, dampingFraction: 0.85), value: store.showExpiredAlert)
+            // 에러 오버레이
+            .overlay {
+                if store.showErrorOverlay {
+                    ErrorOverlayView(
+                        message: store.errorOverlayMessage,
+                        isRetrying: store.isRetryingError,
+                        onRetry: { store.send(.retryFromErrorOverlay) },
+                        onBack: nil
+                    )
+                    .transition(.opacity)
+                }
+            }
+            .animation(.easeInOut(duration: 0.25), value: store.showErrorOverlay)
+            // 재시도 토스트
+            .tteToast(
+                isPresented: Binding(
+                    get: { store.showRetryToast },
+                    set: { if !$0 { store.send(.retryToastDismissed) } }
+                ),
+                message: "잠시 후 다시 시도해 주세요."
+            )
         }
     }
 }

--- a/TeumTeumEat/TeumTeumEat/Features/MainTab/MainTab/Home/HomeFeature.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/MainTab/MainTab/Home/HomeFeature.swift
@@ -110,7 +110,7 @@ struct HomeFeature {
         case startQuizFlow(
             quizzes: [UserQuiz],
             summaryData: ContentSummaryFeature.State,
-            isFirstTime: Bool
+            isQuizGuideSeen: Bool
         )
         case openMyPageRequested
         case startNewGoalTapped
@@ -471,7 +471,7 @@ struct HomeFeature {
                     return .send(.delegate(.startQuizFlow(
                         quizzes: [],
                         summaryData: summaryData,
-                        isFirstTime: true
+                        isQuizGuideSeen: state.quizStatus?.isQuizGuideSeen ?? false
                     )))
 
                 } else if let goal = state.currentGoal,
@@ -490,7 +490,7 @@ struct HomeFeature {
                     return .send(.delegate(.startQuizFlow(
                         quizzes: [],
                         summaryData: summaryData,
-                        isFirstTime: true
+                        isQuizGuideSeen: state.quizStatus?.isQuizGuideSeen ?? false
                     )))
 
                 } else {

--- a/TeumTeumEat/TeumTeumEat/Features/MainTab/MainTab/Home/HomeFeature.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/MainTab/MainTab/Home/HomeFeature.swift
@@ -127,7 +127,7 @@ struct HomeFeature {
                 state.showErrorOverlay = false
                 state.retryCount = 0
                 state.showRetryToast = false
-                
+
                 // 병렬 처리: 캘린더 조회 + 목표 조회
                 let now = Date()
                 let calendar = Calendar.current

--- a/TeumTeumEat/TeumTeumEat/Features/MainTab/MainTab/Home/HomeFeature.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/MainTab/MainTab/Home/HomeFeature.swift
@@ -18,8 +18,8 @@ struct HomeFeature {
         var fireCount: Int = 0
         var stampCount: Int = 0
         var isTodayQuizCompleted: Bool = false
-        var isExpired: Bool = false
-        var showExpiredAlert: Bool = false
+        var isGoalCompleted: Bool = false
+        var showGoalCompletedAlert: Bool = false
         
         // API 관련 상태
         var currentGoal: GoalResponse?
@@ -49,7 +49,7 @@ struct HomeFeature {
         }
         
         var currentSnackImage: String {
-            guard !isExpired else { return "done" }
+            guard !isGoalCompleted else { return "done" }
             guard !isTodayQuizCompleted else { return "done" }
             guard let goal = currentGoal else { return "burger" }
 
@@ -91,6 +91,9 @@ struct HomeFeature {
         case retryFromErrorOverlay
         case dismissErrorOverlay
         case retryToastDismissed
+        case goalCompletedAlertDismissed
+        case goalCompletedNewGoalTapped
+        case goalCompletedSelectExistingTapped
         case settingTapped
         case toggleQuizStatus
         case characterEatTapped
@@ -100,9 +103,6 @@ struct HomeFeature {
         case adRewardEarned
         case postAdRewardResponse(Result<Void, Error>)
         case refreshQuizStatusResponse(Result<UserQuizStatusData, Error>)
-        case expiredAlertDismissed
-        case expiredNewGoalTapped
-        case expiredSelectExistingTapped
         case delegate(Delegate)
     }
 
@@ -171,13 +171,6 @@ struct HomeFeature {
                 state.showErrorOverlay = false
                 state.isRetryingError = false
                 state.retryCount = 0
-                state.isExpired = goal.isExpired
-                if goal.isExpired {
-                    state.currentGoal = goal
-                    state.isLoading = false
-                    print("[Home] Goal 만료")
-                    return .none
-                }
 
                 let previousGoal = state.currentGoal
                 state.currentGoal = goal
@@ -228,7 +221,7 @@ struct HomeFeature {
                 print("[Home] Step2 완료 - hasSolvedToday: \(status.hasSolvedToday)")
 
                 if status.isCompleted {
-                    state.isExpired = true
+                    state.isGoalCompleted = true
                     state.isLoading = false
                     print("[Home] Goal 완료 - 모든 퀴즈 세트 완료")
                     return .none
@@ -252,7 +245,7 @@ struct HomeFeature {
             case .fetchQuizStatusResponse(.failure(let error)):
                 if let apiError = error as? APIError,
                    case .serverError(let code, _, _) = apiError, code == "GOAL-002" {
-                    state.isExpired = true
+                    state.isGoalCompleted = true
                     state.isLoading = false
                     return .none
                 }
@@ -286,7 +279,7 @@ struct HomeFeature {
                 if let apiError = error as? APIError,
                    case .serverError(let code, _, _) = apiError {
                     if code == "GOAL-002" {
-                        state.isExpired = true
+                        state.isGoalCompleted = true
                         state.isLoading = false
                         return .none
                     }
@@ -315,7 +308,7 @@ struct HomeFeature {
                 if let apiError = error as? APIError,
                    case .serverError(let code, _, _) = apiError,
                    code == "GOAL-002" || code == "GOAL-003" {
-                    state.isExpired = true
+                    state.isGoalCompleted = true
                     state.isLoading = false
                     return .none
                 }
@@ -431,25 +424,23 @@ struct HomeFeature {
                 print("퀴즈 상태 새로고침 실패: \(error)")
                 return .none
 
-            case .expiredAlertDismissed:
-                state.showExpiredAlert = false
+            case .goalCompletedAlertDismissed:
+                state.showGoalCompletedAlert = false
                 return .none
 
-            case .expiredNewGoalTapped:
-                state.showExpiredAlert = false
+            case .goalCompletedNewGoalTapped:
+                state.showGoalCompletedAlert = false
                 return .send(.delegate(.startNewGoalTapped))
 
-            case .expiredSelectExistingTapped:
-                state.showExpiredAlert = false
+            case .goalCompletedSelectExistingTapped:
+                state.showGoalCompletedAlert = false
                 return .send(.delegate(.openMyPageRequested))
 
             case .characterEatTapped:
-                if state.isExpired {
-                    state.showExpiredAlert = true
+                if state.isGoalCompleted {
+                    state.showGoalCompletedAlert = true
                     return .none
                 }
-
-                // summaryData 생성 후 QuizFlow에 전달
 
                 if state.isTodayQuizCompleted {
                     print("오늘 퀴즈를 이미 완료했습니다")
@@ -520,7 +511,7 @@ struct HomeView: View {
                 )
                 
                 Spacer()
-                    .frame(height: (store.isTodayQuizCompleted || store.isExpired) ? 5 : 11)
+                    .frame(height: (store.isTodayQuizCompleted || store.isGoalCompleted) ? 5 : 11)
                 
                 if store.isLoading {
                     
@@ -547,7 +538,7 @@ struct HomeView: View {
                 } else {
                     CharacterImageView(
                         isTodayQuizCompleted: store.isTodayQuizCompleted,
-                        isExpired: store.isExpired,
+                        isGoalCompleted: store.isGoalCompleted,
                         currentSnackImage: store.currentSnackImage,
                         onCharacterTapped: {
                             store.send(.characterEatTapped)
@@ -592,21 +583,21 @@ struct HomeView: View {
                 }
             }
             .animation(.spring(response: 0.3, dampingFraction: 0.85), value: store.showCouponModal)
-            // 만료 알럿
+            // 주제 완료 알럿
             .overlay {
-                if store.showExpiredAlert {
+                if store.showGoalCompletedAlert {
                     Color.black.opacity(0.4)
                         .ignoresSafeArea()
-                        .onTapGesture { store.send(.expiredAlertDismissed) }
+                        .onTapGesture { store.send(.goalCompletedAlertDismissed) }
 
-                    ExpiredAlertView(
-                        onNewGoal: { store.send(.expiredNewGoalTapped) },
-                        onSelectExisting: { store.send(.expiredSelectExistingTapped) }
+                    GoalCompletedAlertView(
+                        onNewGoal: { store.send(.goalCompletedNewGoalTapped) },
+                        onSelectExisting: { store.send(.goalCompletedSelectExistingTapped) }
                     )
                     .transition(.scale(scale: 0.95).combined(with: .opacity))
                 }
             }
-            .animation(.spring(response: 0.3, dampingFraction: 0.85), value: store.showExpiredAlert)
+            .animation(.spring(response: 0.3, dampingFraction: 0.85), value: store.showGoalCompletedAlert)
             // 에러 오버레이
             .overlay {
                 if store.showErrorOverlay {
@@ -635,41 +626,39 @@ struct HomeView: View {
 // MARK: - Character Image View
 struct CharacterImageView: View {
     let isTodayQuizCompleted: Bool
-    let isExpired: Bool
+    let isGoalCompleted: Bool
     let currentSnackImage: String
     let onCharacterTapped: () -> Void
     let onSpeechBubbleTapped: () -> Void
 
     var body: some View {
         ZStack(alignment: .center) {
-            // Lottie 배경 (항상 동일한 위치)
-            LottieView(animation: .named((isTodayQuizCompleted || isExpired) ? "home_v2_dummy" : "home_dummy"))
+            // Lottie 배경
+            LottieView(animation: .named((isTodayQuizCompleted || isGoalCompleted) ? "home_v2_dummy" : "home_dummy"))
                 .playing(loopMode: .loop)
                 .frame(height: 548)
                 .offset(x: -10)
 
-            // 오버레이 (만료/완료/미완료에 따라 다름)
             VStack(spacing: 16) {
                 Spacer()
 
-                if isExpired {
-                    // 만료 시 - done 이미지
+                if isGoalCompleted {
+                    // 주제 전체 완료
                     Image("done")
                         .resizable()
                         .scaledToFit()
                         .frame(width: 180, height: 180)
 
-                    Text("학습 기간이\n만료되었어요!")
+                    Text("이 주제의 모든 지식을\n다 먹었어요!")
                         .font(.system(size: 24, weight: .bold))
                         .foregroundColor(.black)
                         .multilineTextAlignment(.center)
 
                 } else if isTodayQuizCompleted {
-                    // 말풍선
+                    // 오늘 완료
                     SpeechBubbleView()
                         .onTapGesture { onSpeechBubbleTapped() }
 
-                    // 완료 시 - done 이미지
                     Image("done")
                         .resizable()
                         .scaledToFit()
@@ -681,7 +670,7 @@ struct CharacterImageView: View {
                         .multilineTextAlignment(.center)
 
                 } else {
-                    // 미완료 시 - 햄버거 + 텍스트
+                    // 미완료 - 퀴즈 대기 중
                     Image(currentSnackImage)
                         .resizable()
                         .scaledToFit()
@@ -702,8 +691,7 @@ struct CharacterImageView: View {
         .padding(.trailing, 3)
         .contentShape(Rectangle())
         .onTapGesture {
-            // 만료 시에는 항상 터치 가능, 완료 시에만 막음
-            if !isTodayQuizCompleted || isExpired {
+            if !isTodayQuizCompleted && !isGoalCompleted {
                 onCharacterTapped()
             }
         }
@@ -817,19 +805,20 @@ struct TriangleUp: Shape {
     }
 }
 
-// MARK: - Expired Alert View
-struct ExpiredAlertView: View {
+
+// MARK: - Goal Completed Alert View
+struct GoalCompletedAlertView: View {
     let onNewGoal: () -> Void
     let onSelectExisting: () -> Void
 
     var body: some View {
         VStack(spacing: 0) {
             VStack(spacing: 8) {
-                Text("풀고 있는 틈틈잇이 없어요")
+                Text("이 주제를 모두 완료했어요!")
                     .font(.system(size: 18, weight: .bold))
                     .foregroundColor(.black)
 
-                Text("먹을 간식이 없어요!\n새로운 지식을 먹여줄래요?")
+                Text("새로운 지식을 먹으러 가볼까요?")
                     .font(.system(size: 14))
                     .foregroundColor(.gray600)
                     .multilineTextAlignment(.center)

--- a/TeumTeumEat/TeumTeumEat/Features/MainTab/MainTab/Home/HomeFeature.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/MainTab/MainTab/Home/HomeFeature.swift
@@ -383,6 +383,7 @@ struct HomeFeature {
 
             case .couponUseTapped:
                 guard state.availableQuizCount > 0 else { return .none }
+                AnalyticsManager.logCouponUsed()
                 state.isTodayQuizCompleted = false
                 state.isUsingCoupon = true
                 state.showCouponModal = false

--- a/TeumTeumEat/TeumTeumEat/Features/MainTab/MainTab/Home/HomeFeature.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/MainTab/MainTab/Home/HomeFeature.swift
@@ -20,6 +20,7 @@ struct HomeFeature {
         var isTodayQuizCompleted: Bool = false
         var isGoalCompleted: Bool = false
         var showGoalCompletedAlert: Bool = false
+        var hasActiveSubjects: Bool = false
         
         // API 관련 상태
         var currentGoal: GoalResponse?
@@ -94,6 +95,7 @@ struct HomeFeature {
         case goalCompletedAlertDismissed
         case goalCompletedNewGoalTapped
         case goalCompletedSelectExistingTapped
+        case fetchActiveGoalsResponse(Result<[GoalResponse], Error>)
         case settingTapped
         case toggleQuizStatus
         case characterEatTapped
@@ -225,7 +227,11 @@ struct HomeFeature {
                     state.showGoalCompletedAlert = true
                     state.isLoading = false
                     print("[Home] Goal 완료 - 모든 퀴즈 세트 완료")
-                    return .none
+                    return .run { send in
+                        await send(.fetchActiveGoalsResponse(
+                            Result { try await apiClient.fetchGoals() }
+                        ))
+                    }
                 }
 
                 if wasCompletedYesterday && !status.hasSolvedToday {
@@ -249,7 +255,11 @@ struct HomeFeature {
                     state.isGoalCompleted = true
                     state.showGoalCompletedAlert = true
                     state.isLoading = false
-                    return .none
+                    return .run { send in
+                        await send(.fetchActiveGoalsResponse(
+                            Result { try await apiClient.fetchGoals() }
+                        ))
+                    }
                 }
                 state.isLoading = false
                 let overlayMsg = (error as? APIError)?.overlayMessage ?? "에러가 발생했습니다."
@@ -284,7 +294,11 @@ struct HomeFeature {
                         state.isGoalCompleted = true
                         state.showGoalCompletedAlert = true
                         state.isLoading = false
-                        return .none
+                        return .run { send in
+                            await send(.fetchActiveGoalsResponse(
+                                Result { try await apiClient.fetchGoals() }
+                            ))
+                        }
                     }
                     if code == "COMMON-005" {
                         // 오늘 문서가 아직 없음 — ContentSummaryFeature가 SSE로 생성
@@ -314,7 +328,11 @@ struct HomeFeature {
                     state.isGoalCompleted = true
                     state.showGoalCompletedAlert = true
                     state.isLoading = false
-                    return .none
+                    return .run { send in
+                        await send(.fetchActiveGoalsResponse(
+                            Result { try await apiClient.fetchGoals() }
+                        ))
+                    }
                 }
                 state.isLoading = false
                 state.errorMessage = "퀴즈 조회 실패: \(error.localizedDescription)"
@@ -426,6 +444,14 @@ struct HomeFeature {
 
             case .refreshQuizStatusResponse(.failure(let error)):
                 print("퀴즈 상태 새로고침 실패: \(error)")
+                return .none
+
+            case .fetchActiveGoalsResponse(.success(let goals)):
+                state.hasActiveSubjects = goals.contains { !$0.isExpired && !$0.isCompleted }
+                return .none
+
+            case .fetchActiveGoalsResponse(.failure):
+                state.hasActiveSubjects = false
                 return .none
 
             case .goalCompletedAlertDismissed:
@@ -594,6 +620,7 @@ struct HomeView: View {
                         .ignoresSafeArea()
 
                     GoalCompletedAlertView(
+                        hasActiveSubjects: store.hasActiveSubjects,
                         onNewGoal: { store.send(.goalCompletedNewGoalTapped) },
                         onSelectExisting: { store.send(.goalCompletedSelectExistingTapped) }
                     )
@@ -811,6 +838,7 @@ struct TriangleUp: Shape {
 
 // MARK: - Goal Completed Alert View
 struct GoalCompletedAlertView: View {
+    let hasActiveSubjects: Bool
     let onNewGoal: () -> Void
     let onSelectExisting: () -> Void
 
@@ -845,12 +873,13 @@ struct GoalCompletedAlertView: View {
                 Button(action: onSelectExisting) {
                     Text("진행중인 틈틈잇 선택하기")
                         .font(.system(size: 16, weight: .semibold))
-                        .foregroundColor(.white)
+                        .foregroundColor(hasActiveSubjects ? .white : .gray400)
                         .frame(maxWidth: .infinity)
                         .frame(height: 52)
-                        .background(Color.blue500)
+                        .background(hasActiveSubjects ? Color.blue500 : Color.gray200)
                         .cornerRadius(12)
                 }
+                .disabled(!hasActiveSubjects)
             }
             .padding(.horizontal, 20)
             .padding(.bottom, 24)

--- a/TeumTeumEat/TeumTeumEat/Features/MainTab/MainTab/Home/HomeFeature.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/MainTab/MainTab/Home/HomeFeature.swift
@@ -222,6 +222,7 @@ struct HomeFeature {
 
                 if status.isCompleted {
                     state.isGoalCompleted = true
+                    state.showGoalCompletedAlert = true
                     state.isLoading = false
                     print("[Home] Goal 완료 - 모든 퀴즈 세트 완료")
                     return .none
@@ -246,6 +247,7 @@ struct HomeFeature {
                 if let apiError = error as? APIError,
                    case .serverError(let code, _, _) = apiError, code == "GOAL-002" {
                     state.isGoalCompleted = true
+                    state.showGoalCompletedAlert = true
                     state.isLoading = false
                     return .none
                 }
@@ -280,6 +282,7 @@ struct HomeFeature {
                    case .serverError(let code, _, _) = apiError {
                     if code == "GOAL-002" {
                         state.isGoalCompleted = true
+                        state.showGoalCompletedAlert = true
                         state.isLoading = false
                         return .none
                     }
@@ -309,6 +312,7 @@ struct HomeFeature {
                    case .serverError(let code, _, _) = apiError,
                    code == "GOAL-002" || code == "GOAL-003" {
                     state.isGoalCompleted = true
+                    state.showGoalCompletedAlert = true
                     state.isLoading = false
                     return .none
                 }
@@ -583,12 +587,11 @@ struct HomeView: View {
                 }
             }
             .animation(.spring(response: 0.3, dampingFraction: 0.85), value: store.showCouponModal)
-            // 주제 완료 알럿
+            // 주제 완료 알럿 (강제 - 배경 탭으로 닫기 불가)
             .overlay {
                 if store.showGoalCompletedAlert {
                     Color.black.opacity(0.4)
                         .ignoresSafeArea()
-                        .onTapGesture { store.send(.goalCompletedAlertDismissed) }
 
                     GoalCompletedAlertView(
                         onNewGoal: { store.send(.goalCompletedNewGoalTapped) },
@@ -691,7 +694,7 @@ struct CharacterImageView: View {
         .padding(.trailing, 3)
         .contentShape(Rectangle())
         .onTapGesture {
-            if !isTodayQuizCompleted && !isGoalCompleted {
+            if !isTodayQuizCompleted {
                 onCharacterTapped()
             }
         }

--- a/TeumTeumEat/TeumTeumEat/Features/MainTab/MainTab/MainTabFeature.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/MainTab/MainTab/MainTabFeature.swift
@@ -123,11 +123,11 @@ struct MainTabFeature {
                     return .none
                     
                 // Home에서 QuizFlow 시작 (summaryData 포함)
-                case .home(.delegate(.startQuizFlow(let quizzes, let summaryData, let isFirstTime))):
+                case .home(.delegate(.startQuizFlow(let quizzes, let summaryData, let isQuizGuideSeen))):
                     state.quizFlow = QuizFlowFeature.State(
                         quizzes: quizzes,
                         summaryData: summaryData,
-                        isFirstTime: isFirstTime
+                        isQuizGuideSeen: isQuizGuideSeen
                     )
                     print("퀴즈 플로우 시작 - 요약부터 표시")
                     return .none

--- a/TeumTeumEat/TeumTeumEat/Features/MainTab/MainTab/MainTabFeature.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/MainTab/MainTab/MainTabFeature.swift
@@ -72,30 +72,33 @@ struct MainTabFeature {
             Reduce { state, action in
                 switch action {
                 case .tabSelected(let tab):
+                    guard !state.home.isGoalCompleted else { return .none }
                     let previousTab = state.selectedTab
                     state.selectedTab = tab
-                    
+
                     if tab != .register {
                         state.isRegisterMenuExpanded = false
                     }
-                    
+
                     // 홈 탭으로 전환될 때 새로고침
                     if tab == .home && previousTab != .home {
                         return .send(.home(.onAppear))
                     }
-                    
+
                     // 히스토리 탭으로 전환될 때 새로고침
                     if tab == .quiz && previousTab != .quiz {
                         return .send(.quiz(.onAppear))
                     }
-                    
+
                     return .none
-                    
+
                 case .toggleRegisterMenu:
+                    guard !state.home.isGoalCompleted else { return .none }
                     state.isRegisterMenuExpanded.toggle()
                     return .none
-                    
+
                 case .registerMenuItemTapped(let item):
+                    guard !state.home.isGoalCompleted else { return .none }
                     print("메뉴 아이템 선택: \(item)")
                     state.isRegisterMenuExpanded = false
                     if item == .category {
@@ -115,6 +118,9 @@ struct MainTabFeature {
 
                 case .newGoalFlow(.delegate(.cancelled)):
                     state.newGoalFlow = nil
+                    if state.home.isGoalCompleted {
+                        state.home.showGoalCompletedAlert = true
+                    }
                     return .none
 
                 case .home(.delegate(.openMyPageRequested)):
@@ -139,6 +145,9 @@ struct MainTabFeature {
                     
                 case .myPage(.delegate(.dismissed)):
                     state.myPage = nil
+                    if state.home.isGoalCompleted {
+                        state.home.showGoalCompletedAlert = true
+                    }
                     print("MyPage 닫힘")
                     return .none
                     

--- a/TeumTeumEat/TeumTeumEat/Features/MainTab/MainTab/MainTabView.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/MainTab/MainTab/MainTabView.swift
@@ -166,7 +166,8 @@ struct CustomTabBar: View {
             TTETabButton(
                 icon: Image("library"),
                 size: .small,
-                isSelected: selectedTab == .quiz
+                isSelected: selectedTab == .quiz,
+                customIconSize: 30
             ) {
                 withAnimation(.spring(response: 0.3, dampingFraction: 0.7)) {
                     onTabSelected(.quiz)

--- a/TeumTeumEat/TeumTeumEat/Features/MainTab/MainTab/MyPage/AppSettingsFeature.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/MainTab/MainTab/MyPage/AppSettingsFeature.swift
@@ -34,48 +34,39 @@ struct AppSettingsFeature {
         var isSaving: Bool = false
         var errorMessage: String?
         
-        // 닉네임 검증 로직 추가
+        // 닉네임 검증 로직
         var nicknameValidationError: String? {
-            let trimmedName = nickname.trimmingCharacters(in: .whitespaces)
-            
-            // 입력이 없으면 에러 메시지 표시 안 함
-            if nickname.isEmpty {
-                return nil
-            }
-            
-            // 길이 체크
-            if trimmedName.count > 10 {
-                return "닉네임은 10글자 이하로 입력해주세요"
-            }
-            
-            // 완성된 한글, 영문, 숫자만 허용
-            let allowedPattern = "^[a-zA-Z0-9가-힣]+$"
+            let trimmed = nickname.trimmingCharacters(in: .whitespaces)
+
+            // 완전히 빈 값이면 에러 미표시
+            if nickname.isEmpty { return nil }
+
+            // 공백만 입력된 경우
+            if trimmed.isEmpty { return "닉네임을 입력해주세요" }
+
+            // 한글, 영문, 숫자, 공백만 허용
+            let allowedPattern = "^[가-힣a-zA-Z0-9 ]*$"
             let predicate = NSPredicate(format: "SELF MATCHES %@", allowedPattern)
-            
-            if !predicate.evaluate(with: trimmedName) {
+            if !predicate.evaluate(with: nickname) {
                 return "한글, 영문, 숫자만 사용 가능해요"
             }
-            
+
             return nil
         }
-        
-        // 닉네임 유효성 체크
+
+        // 닉네임 유효성 체크 (저장 버튼 활성화 기준)
         var isNicknameValid: Bool {
-            let trimmedName = nickname.trimmingCharacters(in: .whitespaces)
-            
-            guard !trimmedName.isEmpty else { return false }
-            guard trimmedName.count >= 1 && trimmedName.count <= 10 else { return false }
-            guard !nickname.contains(" ") else { return false }
-            
-            let allowedPattern = "^[a-zA-Z0-9가-힣]+$"
+            let trimmed = nickname.trimmingCharacters(in: .whitespaces)
+            guard !trimmed.isEmpty else { return false }
+
+            let allowedPattern = "^[가-힣a-zA-Z0-9 ]*$"
             let predicate = NSPredicate(format: "SELF MATCHES %@", allowedPattern)
-            
-            return predicate.evaluate(with: trimmedName)
+            return predicate.evaluate(with: nickname)
         }
-        
+
         // Computed Properties
         var hasChanges: Bool {
-            nickname != originalNickname ||
+            nickname.trimmingCharacters(in: .whitespaces) != originalNickname ||
             leaveTime != originalLeaveTime ||
             returnTime != originalReturnTime ||
             usageMinutes != originalUsageMinutes
@@ -220,10 +211,11 @@ struct AppSettingsFeature {
                 var effects: [Effect<Action>] = []
                 
                 // 이름 변경됐으면
-                if state.nickname != state.originalNickname {
-                    effects.append(.run { [nickname = state.nickname] send in
+                if state.nickname.trimmingCharacters(in: .whitespaces) != state.originalNickname {
+                    let trimmedNickname = state.nickname.trimmingCharacters(in: .whitespaces)
+                    effects.append(.run { send in
                         await send(.updateNameResponse(
-                            Result { try await apiClient.updateUserName(name: nickname) }
+                            Result { try await apiClient.updateUserName(name: trimmedNickname) }
                         ))
                     })
                 }
@@ -255,7 +247,9 @@ struct AppSettingsFeature {
             // MARK: - 업데이트 응답
             case .updateNameResponse(.success):
                 print("이름 업데이트 성공")
-                state.originalNickname = state.nickname
+                let trimmed = state.nickname.trimmingCharacters(in: .whitespaces)
+                state.nickname = trimmed
+                state.originalNickname = trimmed
                 
                 // 출퇴근도 같이 업데이트 중이 아니면 저장 완료
                 if state.leaveTime == state.originalLeaveTime &&
@@ -296,7 +290,7 @@ struct AppSettingsFeature {
                 return .send(.delegate(.dismissed))
                 
             case .nicknameChanged(let nickname):
-                state.nickname = nickname
+                state.nickname = String(nickname.prefix(10))
                 return .none
                 
             case .leaveTimeButtonTapped:

--- a/TeumTeumEat/TeumTeumEat/Features/MainTab/MainTab/MyPage/AppSettingsView.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/MainTab/MainTab/MyPage/AppSettingsView.swift
@@ -84,7 +84,8 @@ struct AppSettingsView: View {
                 ),
                 onDismiss: {
                     store.send(.leaveTimePickerDismissed)
-                }
+                },
+                minuteInterval: 10
             )
         }
         .sheet(isPresented: Binding(
@@ -99,7 +100,8 @@ struct AppSettingsView: View {
                 ),
                 onDismiss: {
                     store.send(.returnTimePickerDismissed)
-                }
+                },
+                minuteInterval: 10
             )
         }
         .sheet(isPresented: Binding(

--- a/TeumTeumEat/TeumTeumEat/Features/MainTab/MainTab/MyPage/AppSettingsView.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/MainTab/MainTab/MyPage/AppSettingsView.swift
@@ -165,7 +165,7 @@ struct AppSettingsView: View {
                 ),
                 placeholder: "닉네임을 입력하세요",
                 state: store.textFieldState,
-                allowSpaces: false
+                allowSpaces: true
             )
             .focused($isNicknameFocused)
         }

--- a/TeumTeumEat/TeumTeumEat/Features/MainTab/MainTab/MyPage/MyPageVIew.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/MainTab/MainTab/MyPage/MyPageVIew.swift
@@ -226,7 +226,7 @@ struct MyPageView: View {
                                 
                                 Spacer()
                                 
-                                Text("v 1.0.0")
+                                Text("v 1.0.8")
                                     .bodyRegular14()
                                     .foregroundColor(.gray)
                             }

--- a/TeumTeumEat/TeumTeumEat/Features/MainTab/MainTab/MyPage/UsageTimePickerModal.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/MainTab/MainTab/MyPage/UsageTimePickerModal.swift
@@ -15,7 +15,17 @@ struct UsageTimePickerModal: View {
     @State private var tempMinutes: Int = 5
     
     let timeOptions = [5, 7, 10, 15]
-    
+
+    private func questionCount(for minutes: Int) -> String {
+        switch minutes {
+        case 5:  return "3문제"
+        case 7:  return "5문제"
+        case 10: return "7문제"
+        case 15: return "10문제"
+        default: return "\(minutes)분"
+        }
+    }
+
     var body: some View {
         VStack(spacing: 0) {
             Spacer()
@@ -72,19 +82,24 @@ struct UsageTimePickerModal: View {
     }
     
     private func timeOptionButton(minutes: Int) -> some View {
-        Button {
+        let isSelected = tempMinutes == minutes
+        return Button {
             tempMinutes = minutes
         } label: {
             HStack {
                 Spacer()
-                Text("\(minutes)분")
+                Text(questionCount(for: minutes))
                     .font(.system(size: 16, weight: .medium))
-                    .foregroundColor(tempMinutes == minutes ? .white : .primary)
+                    .foregroundColor(isSelected ? .blue500 : .gray500)
                 Spacer()
             }
             .padding(.vertical, 16)
-            .background(tempMinutes == minutes ? Color.blue : Color.gray.opacity(0.1))
+            .background(Color.white)
             .cornerRadius(12)
+            .overlay(
+                RoundedRectangle(cornerRadius: 12)
+                    .stroke(isSelected ? Color.blue500 : Color.gray200, lineWidth: isSelected ? 2 : 1)
+            )
         }
     }
 }

--- a/TeumTeumEat/TeumTeumEat/Features/MainTab/MainTab/Quiz/ContentSummaryFeature.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/MainTab/MainTab/Quiz/ContentSummaryFeature.swift
@@ -27,6 +27,9 @@ struct ContentSummaryFeature {
         var isStreaming: Bool = false
         var isQuizLoading: Bool = false
         var errorMessage: String? = nil
+        var showErrorOverlay: Bool = false
+        var errorOverlayMessage: String = ""
+        var isRetryingError: Bool = false
 
         init(
             documentId: Int,
@@ -57,6 +60,8 @@ struct ContentSummaryFeature {
         case startQuizButtonTapped
         case closeButtonTapped
         case errorAlertDismissed
+        case retryFromErrorOverlay
+        case dismissErrorOverlay
         case delegate(Delegate)
 
         case startStreaming
@@ -226,7 +231,12 @@ struct ContentSummaryFeature {
                         }
                     }
                 }
+                // 일반 에러 → 오버레이 표시
                 state.isStreaming = false
+                let overlayMsg = (error as? APIError)?.overlayMessage ?? "에러가 발생했습니다."
+                state.errorOverlayMessage = overlayMsg
+                state.showErrorOverlay = true
+                state.isRetryingError = false
                 return .none
 
             case .fallbackResponse(.success(let doc)):
@@ -306,6 +316,19 @@ struct ContentSummaryFeature {
             case .errorAlertDismissed:
                 state.errorMessage = nil
                 return .send(.delegate(.cancelled))
+
+            case .retryFromErrorOverlay:
+                state.showErrorOverlay = false
+                state.isRetryingError = true
+                return .send(.startStreaming)
+
+            case .dismissErrorOverlay:
+                state.showErrorOverlay = false
+                state.isRetryingError = false
+                return .merge(
+                    .cancel(id: CancelID.streaming),
+                    .send(.delegate(.cancelled))
+                )
 
             case .startQuizButtonTapped:
                 return .send(.delegate(.startQuiz(

--- a/TeumTeumEat/TeumTeumEat/Features/MainTab/MainTab/Quiz/ContentSummaryView.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/MainTab/MainTab/Quiz/ContentSummaryView.swift
@@ -147,6 +147,7 @@ struct ContentSummaryView: View {
         .onAppear {
             store.send(.onAppear)
         }
+        // QUIZ-002: 퀴즈 횟수 소진 알림 (기존 alert 유지)
         .alert(
             "퀴즈를 시작할 수 없어요",
             isPresented: Binding(
@@ -158,6 +159,19 @@ struct ContentSummaryView: View {
         } message: {
             Text(store.errorMessage ?? "")
         }
+        // 일반 에러 오버레이
+        .overlay {
+            if store.showErrorOverlay {
+                ErrorOverlayView(
+                    message: store.errorOverlayMessage,
+                    isRetrying: store.isRetryingError,
+                    onRetry: { store.send(.retryFromErrorOverlay) },
+                    onBack: { store.send(.dismissErrorOverlay) }
+                )
+                .transition(.opacity)
+            }
+        }
+        .animation(.easeInOut(duration: 0.25), value: store.showErrorOverlay)
     }
 }
 

--- a/TeumTeumEat/TeumTeumEat/Features/MainTab/MainTab/Quiz/HisotryFeature.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/MainTab/MainTab/Quiz/HisotryFeature.swift
@@ -31,7 +31,18 @@ struct HistoryFeature {
         
         var topicCategories: [HistoryCategoryResponse] = []
         var isLoadingTopics: Bool = false
-        
+
+        var showOnlyActive: Bool = false
+        var activeGoals: [GoalResponse] = []
+
+        var filteredTopicCategories: [HistoryCategoryResponse] {
+            guard showOnlyActive, !activeGoals.isEmpty else { return topicCategories }
+            let activeNames: Set<String> = Set(activeGoals.compactMap { goal -> String? in
+                goal.type == "CATEGORY" ? goal.category?.name : goal.fileName
+            })
+            return topicCategories.filter { activeNames.contains($0.categoryName) }
+        }
+
         var historyDetailSummary: HistoryDetailSummaryFeature.State?
     }
     
@@ -45,6 +56,8 @@ struct HistoryFeature {
         case historyItemsLoaded(Result<[HistoryItemResponse], Error>)
         case fetchTopicHistories
         case topicHistoriesLoaded(Result<[HistoryCategoryResponse], Error>)
+        case activeGoalsLoaded(Result<[GoalResponse], Error>)
+        case filterToggled
         case historyItemTapped(id: Int, type: String, date: String)
         case historyDetailSummary(HistoryDetailSummaryFeature.Action)
         case delegate(Delegate)
@@ -134,19 +147,37 @@ struct HistoryFeature {
              case .fetchTopicHistories:
                  state.isLoadingTopics = true
                  return .run { send in
-                     await send(.topicHistoriesLoaded(
-                        Result {
-                            try await apiClient.fetchHistoryTopics()
-                        }
-                     ))
+                     await withTaskGroup(of: Void.self) { group in
+                         group.addTask {
+                             await send(.topicHistoriesLoaded(
+                                 Result { try await apiClient.fetchHistoryTopics() }
+                             ))
+                         }
+                         group.addTask {
+                             await send(.activeGoalsLoaded(
+                                 Result { try await apiClient.fetchGoals() }
+                             ))
+                         }
+                     }
                  }
-                 
+
+             case .activeGoalsLoaded(.success(let goals)):
+                 state.activeGoals = goals.filter { !$0.isExpired && !$0.isCompleted }
+                 return .none
+
+             case .activeGoalsLoaded(.failure):
+                 return .none
+
+             case .filterToggled:
+                 state.showOnlyActive.toggle()
+                 return .none
+
              case .topicHistoriesLoaded(.success(let categories)):
                  state.isLoadingTopics = false
                  state.topicCategories = categories
                  print("Topic histories loaded: \(categories.count) categories")
                  return .none
-                 
+
              case .topicHistoriesLoaded(.failure(let error)):
                  state.isLoadingTopics = false
                  print("Failed to load topic histories: \(error)")
@@ -264,15 +295,40 @@ struct HistoryView: View {
                                 case 1:
                                     // 주제별
                                     VStack(spacing: 16) {
+                                        // 진행중인 주제 필터 라디오 버튼
+                                        Button {
+                                            store.send(.filterToggled)
+                                        } label: {
+                                            HStack(spacing: 8) {
+                                                ZStack {
+                                                    Circle()
+                                                        .stroke(
+                                                            store.showOnlyActive ? Color.blue500 : Color.gray300,
+                                                            lineWidth: 1.5
+                                                        )
+                                                        .frame(width: 20, height: 20)
+                                                    if store.showOnlyActive {
+                                                        Circle()
+                                                            .fill(Color.blue500)
+                                                            .frame(width: 10, height: 10)
+                                                    }
+                                                }
+                                                Text("진행중인 주제 보기")
+                                                    .font(.system(size: 14, weight: .medium))
+                                                    .foregroundColor(store.showOnlyActive ? .blue500 : .gray600)
+                                                Spacer()
+                                            }
+                                        }
+
                                         if store.isLoadingTopics {
                                             ProgressView()
                                                 .frame(maxWidth: .infinity, maxHeight: 300)
-                                        } else if store.topicCategories.isEmpty {
-                                            Text("주제별 히스토리가 없습니다")
+                                        } else if store.filteredTopicCategories.isEmpty {
+                                            Text(store.showOnlyActive ? "진행중인 주제의 히스토리가 없습니다" : "주제별 히스토리가 없습니다")
                                                 .foregroundColor(.gray)
                                                 .frame(maxWidth: .infinity, maxHeight: 300)
                                         } else {
-                                            ForEach(store.topicCategories) { category in
+                                            ForEach(store.filteredTopicCategories) { category in
                                                 ExpandableSummaryRow(
                                                     categories: [category.categoryName],
                                                     items: category.histories.map { history in

--- a/TeumTeumEat/TeumTeumEat/Features/MainTab/MainTab/Quiz/HisotryFeature.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/MainTab/MainTab/Quiz/HisotryFeature.swift
@@ -774,7 +774,7 @@ struct DayCell: View {
             if hasQuiz {
                 Circle()
                     .fill(isSelected ? Color.blue500 : Color.blue300)
-                    .frame(width: 40, height: 40)
+                    .frame(width: 28, height: 28)
             }
             
             // 날짜 텍스트

--- a/TeumTeumEat/TeumTeumEat/Features/MainTab/MainTab/Quiz/HisotryFeature.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/MainTab/MainTab/Quiz/HisotryFeature.swift
@@ -75,6 +75,7 @@ struct HistoryFeature {
              case .onAppear:
                  return .run { [year = state.currentYear, month = state.currentMonth] send in
                      await send(.monthChanged(year: year, month: month))
+                     await send(.fetchTopicHistories)
                  }
                  
              case .settingTapped:

--- a/TeumTeumEat/TeumTeumEat/Features/MainTab/MainTab/Quiz/HisotryFeature.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/MainTab/MainTab/Quiz/HisotryFeature.swift
@@ -31,6 +31,8 @@ struct HistoryFeature {
         
         var topicCategories: [HistoryCategoryResponse] = []
         var isLoadingTopics: Bool = false
+        var calendarError: String? = nil
+        var topicError: String? = nil
 
         var showOnlyActive: Bool = false
         var activeGoals: [GoalResponse] = []
@@ -57,6 +59,8 @@ struct HistoryFeature {
         case fetchTopicHistories
         case topicHistoriesLoaded(Result<[HistoryCategoryResponse], Error>)
         case activeGoalsLoaded(Result<[GoalResponse], Error>)
+        case retryCalendar
+        case retryTopicHistories
         case filterToggled
         case historyItemTapped(id: Int, type: String, date: String)
         case historyDetailSummary(HistoryDetailSummaryFeature.Action)
@@ -125,14 +129,17 @@ struct HistoryFeature {
                  
              case .calendarDataLoaded(.success(let data)):
                  state.calendarData = data
+                 state.calendarError = nil
                  // stampCount를 totalStamps로 업데이트
                  state.fireCount = data.currentStreak
                  state.stampCount = data.totalStamps
                  print("Calendar data loaded: \(data.currentStreak) stamped dates, total: \(data.totalStamps)")
                  return .none
-                 
+
              case .calendarDataLoaded(.failure(let error)):
-                 print("    Failed to load calendar data: \(error)")
+                 let msg = (error as? APIError)?.overlayMessage ?? "에러가 발생했습니다."
+                 state.calendarError = msg
+                 print("Failed to load calendar data: \(error)")
                  return .none
                  
              case .historyItemsLoaded(.success(let items)):
@@ -169,18 +176,33 @@ struct HistoryFeature {
              case .activeGoalsLoaded(.failure):
                  return .none
 
+             case .retryCalendar:
+                 state.calendarError = nil
+                 return .run { [year = state.currentYear, month = state.currentMonth] send in
+                     await send(.calendarDataLoaded(
+                         Result { try await apiClient.fetchCalendarHistory(year: year, month: month) }
+                     ))
+                 }
+
+             case .retryTopicHistories:
+                 state.topicError = nil
+                 return .send(.fetchTopicHistories)
+
              case .filterToggled:
                  state.showOnlyActive.toggle()
                  return .none
 
              case .topicHistoriesLoaded(.success(let categories)):
                  state.isLoadingTopics = false
+                 state.topicError = nil
                  state.topicCategories = categories
                  print("Topic histories loaded: \(categories.count) categories")
                  return .none
 
              case .topicHistoriesLoaded(.failure(let error)):
                  state.isLoadingTopics = false
+                 let msg = (error as? APIError)?.overlayMessage ?? "에러가 발생했습니다."
+                 state.topicError = msg
                  print("Failed to load topic histories: \(error)")
                  return .none
                  
@@ -252,42 +274,49 @@ struct HistoryView: View {
                                         HistoryDateCard(
                                             fireCount: store.fireCount
                                         )
-                                        
-                                        // 스탬프 카운트 HStack
-                                        HStack(spacing: 12) {
-                                            StampCountCapsule(
-                                                title: "총 스탬프",
-                                                count: store.calendarData?.totalStamps ?? 0,
-                                                iconName: "stamp",
-                                                backgroundColor: Color(hex: "EAF4FF")
+
+                                        if let calendarError = store.calendarError {
+                                            InlineErrorView(
+                                                message: calendarError,
+                                                onRetry: { store.send(.retryCalendar) }
                                             )
-                                            
-                                            StampCountCapsule(
-                                                title: "이번달 스탬프",
-                                                count: store.calendarData?.stampedDates.count ?? 0,
-                                                iconName: "stamp",
-                                                backgroundColor: Color(hex: "EAF4FF")
-                                            )
-                                        }
-                                        
-                                        HistoryCalendarView(
-                                            currentYear: store.currentYear,
-                                            currentMonth: store.currentMonth,
-                                            stampedDates: store.calendarData?.stampedDates ?? [],
-                                            selectedDateString: store.selectedDateString,
-                                            historyItems: store.selectedDateHistoryItems,
-                                            onMonthChanged: { year, month in
-                                                store.send(.monthChanged(year: year, month: month))
-                                            },
-                                            onDateSelected: { dateString in
-                                                store.send(.dateSelected(dateString))
-                                            },
-                                            onItemTapped: { id, type, date in
-                                                store.send(.historyItemTapped(id: id, type: type, date: date))
+                                        } else {
+                                            // 스탬프 카운트 HStack
+                                            HStack(spacing: 12) {
+                                                StampCountCapsule(
+                                                    title: "총 스탬프",
+                                                    count: store.calendarData?.totalStamps ?? 0,
+                                                    iconName: "stamp",
+                                                    backgroundColor: Color(hex: "EAF4FF")
+                                                )
+
+                                                StampCountCapsule(
+                                                    title: "이번달 스탬프",
+                                                    count: store.calendarData?.stampedDates.count ?? 0,
+                                                    iconName: "stamp",
+                                                    backgroundColor: Color(hex: "EAF4FF")
+                                                )
                                             }
-                                        )
-                                        .padding(.top, 5)
-                                        .id("calendar")  // ID 추가
+
+                                            HistoryCalendarView(
+                                                currentYear: store.currentYear,
+                                                currentMonth: store.currentMonth,
+                                                stampedDates: store.calendarData?.stampedDates ?? [],
+                                                selectedDateString: store.selectedDateString,
+                                                historyItems: store.selectedDateHistoryItems,
+                                                onMonthChanged: { year, month in
+                                                    store.send(.monthChanged(year: year, month: month))
+                                                },
+                                                onDateSelected: { dateString in
+                                                    store.send(.dateSelected(dateString))
+                                                },
+                                                onItemTapped: { id, type, date in
+                                                    store.send(.historyItemTapped(id: id, type: type, date: date))
+                                                }
+                                            )
+                                            .padding(.top, 5)
+                                            .id("calendar")
+                                        }
                                     }
                                     .padding(.horizontal, 20)
                                     .padding(.top, 20)
@@ -327,6 +356,11 @@ struct HistoryView: View {
                                         if store.isLoadingTopics {
                                             ProgressView()
                                                 .frame(maxWidth: .infinity, maxHeight: 300)
+                                        } else if let topicError = store.topicError {
+                                            InlineErrorView(
+                                                message: topicError,
+                                                onRetry: { store.send(.retryTopicHistories) }
+                                            )
                                         } else if store.filteredTopicCategories.isEmpty {
                                             Text(store.showOnlyActive ? "진행중인 주제의 히스토리가 없습니다" : "주제별 히스토리가 없습니다")
                                                 .foregroundColor(.gray)

--- a/TeumTeumEat/TeumTeumEat/Features/MainTab/MainTab/Quiz/HisotryFeature.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/MainTab/MainTab/Quiz/HisotryFeature.swift
@@ -303,15 +303,18 @@ struct HistoryView: View {
                                             HStack(spacing: 8) {
                                                 ZStack {
                                                     Circle()
+                                                        .fill(store.showOnlyActive ? Color.blue500 : Color.clear)
+                                                        .frame(width: 20, height: 20)
+                                                    Circle()
                                                         .stroke(
                                                             store.showOnlyActive ? Color.blue500 : Color.gray300,
                                                             lineWidth: 1.5
                                                         )
                                                         .frame(width: 20, height: 20)
                                                     if store.showOnlyActive {
-                                                        Circle()
-                                                            .fill(Color.blue500)
-                                                            .frame(width: 10, height: 10)
+                                                        Image(systemName: "checkmark")
+                                                            .font(.system(size: 11, weight: .bold))
+                                                            .foregroundColor(.white)
                                                     }
                                                 }
                                                 Text("진행중인 주제 보기")

--- a/TeumTeumEat/TeumTeumEat/Features/MainTab/MainTab/Quiz/QuizFlowFeature.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/MainTab/MainTab/Quiz/QuizFlowFeature.swift
@@ -88,6 +88,7 @@ struct QuizFlowFeature {
                     state.currentStep = .quiz
                     let convertedQuizzes = quizzes.map { Quiz(from: $0) }
                     state.quiz = QuizFeature.State(quizzes: convertedQuizzes)
+                    AnalyticsManager.logQuizStart(quizCount: quizzes.count)
                     print("QuizFlow: 퀴즈로 바로 이동 - complete-set 호출")
                     return .run { send in
                         do {
@@ -111,6 +112,7 @@ struct QuizFlowFeature {
                 state.currentStep = .quiz
                 let convertedQuizzes = state.quizzes.map { Quiz(from: $0) }
                 state.quiz = QuizFeature.State(quizzes: convertedQuizzes)
+                AnalyticsManager.logQuizStart(quizCount: state.quizzes.count)
                 print("QuizFlow: 안내 완료, 퀴즈 시작 - complete-set 호출")
                 return .run { send in
                     do {
@@ -131,10 +133,14 @@ struct QuizFlowFeature {
                 
             case .quiz(.delegate(.completed)):
                 state.currentStep = .result
-                
+
                 let quizState = state.quiz
+                let submitResults = quizState?.submitResults ?? [:]
+                let correctCount = submitResults.values.filter { $0.isCorrect }.count
+                AnalyticsManager.logQuizComplete(quizCount: state.quizzes.count, correctCount: correctCount)
+
                 state.result = QuizResultFeature.State(
-                    submitResults: quizState?.submitResults ?? [:],
+                    submitResults: submitResults,
                     totalQuizCount: state.quizzes.count
                 )
                 print("QuizFlow: 결과 화면으로 이동")

--- a/TeumTeumEat/TeumTeumEat/Features/MainTab/MainTab/Quiz/QuizFlowFeature.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/MainTab/MainTab/Quiz/QuizFlowFeature.swift
@@ -13,8 +13,8 @@ struct QuizFlowFeature {
     @ObservableState
     struct State: Equatable {
         var quizzes: [UserQuiz]
-        var isFirstTime: Bool
-        
+        var isQuizGuideSeen: Bool
+
         var currentStep: Step
         var contentSummary: ContentSummaryFeature.State
         var quizGuide: QuizGuideFeature.State?
@@ -37,10 +37,10 @@ struct QuizFlowFeature {
         init(
             quizzes: [UserQuiz],
             summaryData: ContentSummaryFeature.State,
-            isFirstTime: Bool
+            isQuizGuideSeen: Bool
         ) {
             self.quizzes = quizzes
-            self.isFirstTime = isFirstTime
+            self.isQuizGuideSeen = isQuizGuideSeen
             self.currentStep = .summary
             self.contentSummary = summaryData
         }
@@ -77,12 +77,12 @@ struct QuizFlowFeature {
 
         Reduce { state, action in
             switch action {
-            case .contentSummary(.delegate(.startQuiz(let quizzes, let isFirstTime))):
+            case .contentSummary(.delegate(.startQuiz(let quizzes, _))):
                 state.quizzes = quizzes  // ContentSummary에서 로드한 실제 퀴즈 목록 저장
-                if isFirstTime {
+                if !state.isQuizGuideSeen {
                     state.currentStep = .quizGuide
                     state.quizGuide = QuizGuideFeature.State()
-                    print("QuizFlow: 퀴즈 가이드로 이동")
+                    print("QuizFlow: 퀴즈 가이드로 이동 (isQuizGuideSeen=false)")
                     return .none
                 } else {
                     state.currentStep = .quiz

--- a/TeumTeumEat/TeumTeumEat/Features/MainTab/MainTab/Quiz/QuizGuideFeature.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/MainTab/MainTab/Quiz/QuizGuideFeature.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 import ComposableArchitecture
+import OnboardingFeature
 
 @Reducer
 struct QuizGuideFeature {
@@ -15,9 +16,12 @@ struct QuizGuideFeature {
         // 안내 화면 상태
         var isCheckboxSelected: Bool = false
         var isSubmitting: Bool = false
+        var quizCount: Int = 3
     }
-    
+
     enum Action {
+        case onAppear
+        case commuteInfoLoaded(Result<CommuteInfoData, Error>)
         case checkboxToggled
         case startQuizButtonTapped
         case updateQuizGuideResponse(Result<Void, Error>)
@@ -33,6 +37,25 @@ struct QuizGuideFeature {
     var body: some ReducerOf<Self> {
         Reduce { state, action in
             switch action {
+            case .onAppear:
+                return .run { send in
+                    await send(.commuteInfoLoaded(
+                        Result { try await apiClient.fetchCommuteInfo() }
+                    ))
+                }
+
+            case .commuteInfoLoaded(.success(let info)):
+                switch info.usageTime {
+                case 5:  state.quizCount = 3
+                case 7:  state.quizCount = 5
+                case 10: state.quizCount = 7
+                default: state.quizCount = info.usageTime >= 15 ? 10 : 3
+                }
+                return .none
+
+            case .commuteInfoLoaded(.failure):
+                return .none
+
             case .checkboxToggled:
                 state.isCheckboxSelected.toggle()
                 print("체크박스 토글: \(state.isCheckboxSelected)")

--- a/TeumTeumEat/TeumTeumEat/Features/MainTab/MainTab/Quiz/QuizGuideView.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/MainTab/MainTab/Quiz/QuizGuideView.swift
@@ -83,7 +83,7 @@ struct QuizGuideView: View {
                                     .scaledToFit()
                                     .frame(width: 24, height: 24)
                                 
-                                Text("총 3문제가 등장해요")
+                                Text("총 \(store.quizCount)문제가 등장해요")
                                     .font(.system(size: 15))
                                     .foregroundColor(.black)
                             }
@@ -169,5 +169,6 @@ struct QuizGuideView: View {
         }
         .background(.white)
         .navigationBarHidden(true)
+        .onAppear { store.send(.onAppear) }
     }
 }

--- a/TeumTeumEat/TeumTeumEat/Features/Shared/AnalyticsManager.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/Shared/AnalyticsManager.swift
@@ -1,0 +1,44 @@
+//
+//  AnalyticsManager.swift
+//  TeumTeumEat
+//
+//  Created by 임재현 on 6/23/26.
+//
+
+import Foundation
+import FirebaseAnalytics
+
+enum AnalyticsManager {
+    static func logLogin(method: String) {
+        Analytics.logEvent(AnalyticsEventLogin, parameters: [
+            AnalyticsParameterMethod: method
+        ])
+    }
+
+    static func logSignUp(method: String) {
+        Analytics.logEvent(AnalyticsEventSignUp, parameters: [
+            AnalyticsParameterMethod: method
+        ])
+    }
+
+    static func logOnboardingComplete() {
+        Analytics.logEvent("onboarding_complete", parameters: nil)
+    }
+
+    static func logQuizStart(quizCount: Int) {
+        Analytics.logEvent("quiz_start", parameters: [
+            "quiz_count": quizCount
+        ])
+    }
+
+    static func logQuizComplete(quizCount: Int, correctCount: Int) {
+        Analytics.logEvent("quiz_complete", parameters: [
+            "quiz_count": quizCount,
+            "correct_count": correctCount
+        ])
+    }
+
+    static func logCouponUsed() {
+        Analytics.logEvent("coupon_used", parameters: nil)
+    }
+}

--- a/TeumTeumEat/TeumTeumEat/Features/Shared/ErrorOverlayView.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/Shared/ErrorOverlayView.swift
@@ -1,0 +1,85 @@
+//
+//  ErrorOverlayView.swift
+//  TeumTeumEat
+//
+//  Created by 임재현 on 6/21/26.
+//
+
+import SwiftUI
+
+struct ErrorOverlayView: View {
+    let message: String
+    let isRetrying: Bool
+    let onRetry: () -> Void
+    let onBack: (() -> Void)?
+
+    var body: some View {
+        ZStack {
+            Color.black.opacity(0.5)
+                .ignoresSafeArea()
+
+            VStack(spacing: 0) {
+                VStack(spacing: 16) {
+                    Image(systemName: "wifi.exclamationmark")
+                        .font(.system(size: 40))
+                        .foregroundColor(.gray400)
+
+                    Text(message)
+                        .font(.system(size: 15, weight: .medium))
+                        .foregroundColor(.gray700)
+                        .multilineTextAlignment(.center)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                .padding(.top, 32)
+                .padding(.horizontal, 24)
+
+                Spacer().frame(height: 28)
+
+                VStack(spacing: 12) {
+                    Button(action: onRetry) {
+                        Group {
+                            if isRetrying {
+                                HStack(spacing: 8) {
+                                    ProgressView()
+                                        .progressViewStyle(CircularProgressViewStyle(tint: .white))
+                                        .scaleEffect(0.85)
+                                    Text("다시 시도 중...")
+                                        .font(.system(size: 16, weight: .semibold))
+                                        .foregroundColor(.white)
+                                }
+                            } else {
+                                Text("다시 시도")
+                                    .font(.system(size: 16, weight: .semibold))
+                                    .foregroundColor(.white)
+                            }
+                        }
+                        .frame(maxWidth: .infinity)
+                        .frame(height: 52)
+                        .background(isRetrying ? Color.blue500.opacity(0.6) : Color.blue500)
+                        .cornerRadius(12)
+                    }
+                    .disabled(isRetrying)
+
+                    if let onBack = onBack {
+                        Button(action: onBack) {
+                            Text("뒤로가기")
+                                .font(.system(size: 16, weight: .semibold))
+                                .foregroundColor(.gray600)
+                                .frame(maxWidth: .infinity)
+                                .frame(height: 52)
+                                .background(Color.gray100)
+                                .cornerRadius(12)
+                        }
+                        .disabled(isRetrying)
+                    }
+                }
+                .padding(.horizontal, 24)
+                .padding(.bottom, 28)
+            }
+            .background(Color.white)
+            .cornerRadius(20)
+            .padding(.horizontal, 32)
+            .shadow(color: .black.opacity(0.15), radius: 20, x: 0, y: 4)
+        }
+    }
+}

--- a/TeumTeumEat/TeumTeumEat/Features/Shared/InlineErrorView.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/Shared/InlineErrorView.swift
@@ -1,0 +1,40 @@
+//
+//  InlineErrorView.swift
+//  TeumTeumEat
+//
+//  Created by 임재현 on 6/21/26.
+//
+
+import SwiftUI
+
+struct InlineErrorView: View {
+    let message: String
+    let onRetry: () -> Void
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "exclamationmark.triangle")
+                .font(.system(size: 36))
+                .foregroundColor(.gray400)
+
+            Text(message)
+                .font(.system(size: 14, weight: .medium))
+                .foregroundColor(.gray600)
+                .multilineTextAlignment(.center)
+
+            Button(action: onRetry) {
+                Text("다시 시도")
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundColor(.blue500)
+                    .padding(.horizontal, 24)
+                    .padding(.vertical, 10)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 8)
+                            .stroke(Color.blue500, lineWidth: 1)
+                    )
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding(.vertical, 40)
+    }
+}

--- a/TeumTeumEat/TeumTeumEat/Features/Splash/SplashFeature.swift
+++ b/TeumTeumEat/TeumTeumEat/Features/Splash/SplashFeature.swift
@@ -47,7 +47,7 @@ struct SplashFeature {
                 return .run { send in
                     let remoteConfig = RemoteConfig.remoteConfig()
                     let settings = RemoteConfigSettings()
-                    settings.minimumFetchInterval = 0 // TODO: 출시 전 3600으로 변경
+                    settings.minimumFetchInterval = 3600
                     remoteConfig.configSettings = settings
                     remoteConfig.setDefaults(["minimum_required_version": "1.0.0" as NSObject])
 
@@ -73,7 +73,7 @@ struct SplashFeature {
 
             case .openAppStore:
                 return .run { _ in
-                    if let url = URL(string: "itms-apps://itunes.apple.com/app/id YOUR_APP_ID") {
+                    if let url = URL(string: "itms-apps://itunes.apple.com/app/id6757255726") {
                         await openURL(url)
                     }
                 }


### PR DESCRIPTION
## 🎫 What is the PR?
앱스토어 배포 전 QA에서 발견된 버그 수정 및 UX 개선 사항을 반영한 QA 브랜치입니다.
에러 핸들링 UI 추가, 주제 완료 플로우 개선, 카테고리 depth 동적 처리 등 전반적인 품질 개선 작업이 포함됩니다.

## 🎫 Changes
- [feat] 주제 완료(isGoalCompleted) 시 Alert 자동 표시 및 탭 전환 강제 차단
- [feat] 주제 완료 Alert에서 진행중인 틈틈잇 없을 경우 선택 버튼 비활성화
- [feat] 카테고리 depth에 따라 subCategory 화면 동적 스킵 처리 (3뎁스/4뎁스 유동 대응)
- [feat] 만료 상태 제거 및 주제 완료 UI/Alert 추가
- [feat] Firebase Analytics 이벤트 로깅 추가 및 닉네임 공백 허용 수정
- [feat] 에러 핸들링 UI 구현 (ErrorOverlay, RetryToast)
- [feat] 퀴즈 안내 화면 문제 수 usageTime 기반 동적 표시
- [feat] 쿠폰 사용 버튼 쿠폰 보유 시 활성화 스타일 적용
- [feat] 학습분량 모달 문제수 워딩 변경 및 선택 스타일 테두리로 수정
- [feat] 히스토리 탭 버튼 아이콘 크기 확대
- [feat] 온보딩 기간 선택 버튼 테두리 스타일로 변경
- [feat] 버전 1.0.8 업데이트 및 MyPage 수정
- [fix] RemoteConfig fetch interval 3600 설정 및 앱스토어 URL 적용
- [fix] QuizGuide 표시 조건 수정 및 SSE 처리 개선
- [fix] 온보딩 로딩 에러 Alert 취소 버튼 중복 제거
- [fix] 설정 알림시간 피커 10분 단위로 변경
- [fix] 로그인 화면 에러 메시지 레이블 제거
- [fix] 캘린더 날짜 동그라미 크기 텍스트에 맞게 축소
- [fix] 쿠폰 버튼 horizontal padding 조정
- [chore] .gitignore에 .md 파일 추적 제외 추가

## 🎫 Thoughts

**주제 완료 강제 플로우**
단순히 완료 화면을 보여주는 것에서 나아가, 완료 상태에서 유저가 반드시 다음 액션을 선택하도록 강제하는 UX로 변경했습니다.
Alert를 배경 탭으로 닫을 수 없게 하고, MainTabFeature에서 탭 전환 자체를 차단하여 어떤 경로로도 우회할 수 없도록 했습니다.
Alert에서 뒤로가기 후 복귀 시에도 Alert가 유지되도록 NewGoalFlow cancel / MyPage dismiss 시점에 재표시 로직을 추가했습니다.

**카테고리 depth 동적 처리**
기존에는 subCategory 단계를 항상 거쳤으나, 백엔드 데이터의 pathComponents를 기준으로 path[3]의 존재 여부를 런타임에 판단해 3뎁스/4뎁스 카테고리 모두 올바른 화면 경로를 타도록 개선했습니다.

## 🎫 Screenshot

|    구현 내용    |   SE   |   13 mini   |   15 pro   |
| :-------------: | :----------: | :----------: | :----------: |
| GIF | <img src="" width="250"> | <img src="" width="250"> | <img src="" width="250"> |

## 🎫 To Reviewers
- 주제 완료 Alert 강제 표시 플로우가 의도한 대로 모든 진입 경로(새 목표 취소, MyPage 복귀)에서 유지되는지 확인 부탁드립니다.
- `MainTabFeature`에서 `state.home.isGoalCompleted`를 직접 참조해 탭 전환을 차단하는 방식이 적절한지 검토 부탁드립니다.

## 🖥️ 주요 코드 설명

### `HomeFeature`
- `isGoalCompleted = true` 세팅 시 `showGoalCompletedAlert = true`를 함께 세팅해 Alert 자동 표시
- `fetchGoals()` 호출로 진행중인 틈틈잇 존재 여부(`hasActiveSubjects`)를 확인해 Alert 버튼 활성화 제어

```swift
if status.isCompleted {
    state.isGoalCompleted = true
    state.showGoalCompletedAlert = true
    state.isLoading = false
    return .run { send in
        await send(.fetchActiveGoalsResponse(
            Result { try await apiClient.fetchGoals() }
        ))
    }
}
```

### `MainTabFeature`
- `tabSelected`, `toggleRegisterMenu`, `registerMenuItemTapped` 모두 `isGoalCompleted`이면 차단
- `NewGoalFlow` cancel / `MyPage` dismiss 시 `isGoalCompleted`이면 Alert 재표시

```swift
case .tabSelected(let tab):
    guard !state.home.isGoalCompleted else { return .none }
    // ...

case .newGoalFlow(.delegate(.cancelled)):
    state.newGoalFlow = nil
    if state.home.isGoalCompleted {
        state.home.showGoalCompletedAlert = true
    }
    return .none
```

### `CategorySelectionFeature`
- `currentSubCategories.isEmpty` 여부로 3뎁스/4뎁스를 런타임 판단해 subCategory 화면 동적 스킵

```swift
case .mainCategory:
    if state.currentSubCategories.isEmpty {
        state.selectedSubCategory = nil
        state.currentStep = .detailCategory
    } else {
        state.currentStep = .subCategory
    }
    return .none
```

## ✅ Check List
- [ ] Merge 대상 브랜치가 올바른가?
- [ ] 최종 코드가 에러 없이 잘 동작하는가?
- [ ] 전체 변경사항이 500줄을 넘지 않는가?

## 🎫 Related Issues
- Resolved: #58